### PR TITLE
Ar fixes segfaults with broken icc

### DIFF
--- a/IccProfLib/IccIO.cpp
+++ b/IccProfLib/IccIO.cpp
@@ -723,13 +723,12 @@ icInt32Number CIccMemIO::Read8(void *pBuf, icInt32Number nNum)
 {
   if (!m_pData)
     return 0;
-
-  nNum = __min((icInt32Number)(m_nSize-m_nPos), nNum);
-
-  memcpy(pBuf, m_pData+m_nPos, nNum);
-  m_nPos += nNum;
-
-  return nNum;
+  if (nNum > 0) {
+      nNum = __min((icInt32Number) (m_nSize - m_nPos), nNum);
+      memcpy(pBuf, m_pData + m_nPos, nNum);
+      m_nPos += nNum;
+  }
+    return nNum;
 }
 
 

--- a/IccProfLib/IccTagBasic.cpp
+++ b/IccProfLib/IccTagBasic.cpp
@@ -279,13 +279,15 @@ bool CIccTagUnknown::Read(icUInt32Number size, CIccIO *pIO)
 
   m_nSize = size - sizeof(icTagTypeSignature);
 
-  if (m_nSize) {
+  if (m_nSize > 0) { // size could be stored as smaller than expected value, therefore the size check
 
     m_pData = new icUInt8Number[m_nSize];
 
     if (pIO->Read8(m_pData, m_nSize) != (icInt32Number)m_nSize) {
       return false;
     }
+  } else {
+      return false;
   }
 
   return true;


### PR DESCRIPTION
Hi,

the following fixes some segfault issues with ICCProfLib.
The problem is that the original code was not very robust against malicious ICC profiles (caused by bitrot or whatever). In the two individual patches it says what the cause is. It would be good if the small changes could be applied, as they make the library a bit more robust.