### PR TITLE
Fix to the typo in the Absolute Colorimetric xml value

### DIFF
--- a/Testing/Named/FluorescentNamedColor.xml
+++ b/Testing/Named/FluorescentNamedColor.xml
@@ -9,7 +9,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
     </PCSIlluminant>

--- a/Testing/Named/NamedColor.xml
+++ b/Testing/Named/NamedColor.xml
@@ -9,7 +9,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
     </PCSIlluminant>

--- a/Testing/Named/SparseMatrixNamedColor.xml
+++ b/Testing/Named/SparseMatrixNamedColor.xml
@@ -9,7 +9,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.96420288" Y="1.00000000" Z="0.82490540"/>
     </PCSIlluminant>

--- a/Testing/PCC/Lab_float-D50_2deg.xml
+++ b/Testing/PCC/Lab_float-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Lab_float-D93_2deg-MAT.xml
+++ b/Testing/PCC/Lab_float-D93_2deg-MAT.xml
@@ -9,7 +9,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber  X="0.953207786537757" Y="1.000000000000000" Z="1.413571444350848"/>
     </PCSIlluminant>

--- a/Testing/PCC/Lab_int-D50_2deg.xml
+++ b/Testing/PCC/Lab_int-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec380_10_730-D50_2deg.xml
+++ b/Testing/PCC/Spec380_10_730-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec380_10_730-D65_2deg-MAT.xml
+++ b/Testing/PCC/Spec380_10_730-D65_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec380_1_780-D50_2deg.xml
+++ b/Testing/PCC/Spec380_1_780-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec380_5_780-D50_2deg.xml
+++ b/Testing/PCC/Spec380_5_780-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-B_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-B_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8920744919559823" Y="0.9999999999999997" Z="4.7469528485335415"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-B_2deg-CAM.xml
+++ b/Testing/PCC/Spec400_10_700-B_2deg-CAM.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8920744919559823" Y="0.9999999999999997" Z="4.7469528485335415"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-B_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-B_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8920744919559823" Y="0.9999999999999997" Z="4.7469528485335415"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-B_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-B_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8920744919559823" Y="0.9999999999999997" Z="4.7469528485335415"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_10deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-D50_10deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.967253650941049" Y="1.00000000" Z="0.813829270318576"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_10deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D50_10deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.967253650941049" Y="1.00000000" Z="0.813829270318576"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_20yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D50_20yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
 		<XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-D50_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_2deg.xml
+++ b/Testing/PCC/Spec400_10_700-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_40yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D50_40yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
 		<XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_60yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D50_60yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
 		<XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D50_80yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D50_80yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
 		<XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_10deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-D65_10deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.948117925171412" Y="1.00000000" Z="1.073241144203759"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_10deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D65_10deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.948117925171412" Y="1.00000000" Z="1.073241144203759"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_20yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D65_20yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-D65_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D65_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_40yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D65_40yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_60yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D65_60yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D65_80yo2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D65_80yo2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D93_10deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-D93_10deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.942924663587800" Y="1.000000000000000" Z="1.385991249402460"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D93_10deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D93_10deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.942924663587800" Y="1.000000000000000" Z="1.385991249402460"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D93_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-D93_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.953207786537757" Y="1.000000000000000" Z="1.413571444350848"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-D93_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-D93_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.953207786537757" Y="1.000000000000000" Z="1.413571444350848"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DB_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-DB_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.9211143028638444" Y="1.0000000000000000" Z="3.1448735270510038"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DB_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-DB_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.9211143028638444" Y="1.0000000000000000" Z="3.1448735270510038"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DB_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-DB_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.9211143028638444" Y="1.0000000000000000" Z="3.1448735270510038"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DG_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-DG_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.4643641202059271" Y="0.9999999999999999" Z="0.3055280484183189"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DG_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-DG_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.4643641202059271" Y="0.9999999999999999" Z="0.3055280484183189"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DG_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-DG_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.4643641202059271" Y="0.9999999999999999" Z="0.3055280484183189"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DR_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-DR_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.6390774123258092" Y="1.0000000000000002" Z="0.3654359243754366"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DR_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-DR_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.6390774123258092" Y="1.0000000000000002" Z="0.3654359243754366"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-DR_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-DR_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.6390774123258092" Y="1.0000000000000002" Z="0.3654359243754366"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-F11_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-F11_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.009610069583287" Y="1.00000000" Z="0.643505852163255"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-G_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-G_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.3410653285957594" Y="0.9999999999999999" Z="0.1774663564478030"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-G_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-G_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.3410653285957594" Y="0.9999999999999999" Z="0.1774663564478030"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-G_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-G_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.3410653285957594" Y="0.9999999999999999" Z="0.1774663564478030"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-IllumA_10deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-IllumA_10deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.111439205596059" Y="1.00000000" Z="0.351995229719406"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-IllumA_10deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-IllumA_10deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.111439205596059" Y="1.00000000" Z="0.351995229719406"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-IllumA_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-IllumA_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.098489888501049" Y="1.00000000" Z="0.355824758532463"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-IllumA_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-IllumA_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.098489888501049" Y="1.00000000" Z="0.355824758532463"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-N_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-N_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8992991060883163" Y="1.0000000000000002" Z="0.8820741291979884"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-N_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-N_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8992991060883163" Y="1.0000000000000002" Z="0.8820741291979884"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-N_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-N_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.8992991060883163" Y="1.0000000000000002" Z="0.8820741291979884"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-R1_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-R1_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.9584952109329803" Y="1.0000000000000000" Z="0.1531537014436150"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-R1_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-R1_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.9584952109329803" Y="1.0000000000000000" Z="0.1531537014436150"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-R1_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-R1_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="1.9584952109329803" Y="1.0000000000000000" Z="0.1531537014436150"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-R2_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-R2_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="2.1097202156472501" Y="0.9999999999999996" Z="0.0463850013577531"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-R2_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-R2_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="2.1097202156472501" Y="0.9999999999999996" Z="0.0463850013577531"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-R2_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-R2_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="2.1097202156472501" Y="0.9999999999999996" Z="0.0463850013577531"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-Y_2deg-Abs.xml
+++ b/Testing/PCC/Spec400_10_700-Y_2deg-Abs.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.9561077188570063" Y="0.9999999999999999" Z="0.4836029325166304"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-Y_2deg-CAT02.xml
+++ b/Testing/PCC/Spec400_10_700-Y_2deg-CAT02.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.9561077188570063" Y="0.9999999999999999" Z="0.4836029325166304"/>
     </PCSIlluminant>

--- a/Testing/PCC/Spec400_10_700-Y_2deg-MAT.xml
+++ b/Testing/PCC/Spec400_10_700-Y_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.9561077188570063" Y="0.9999999999999999" Z="0.4836029325166304"/>
     </PCSIlluminant>

--- a/Testing/PCC/XYZ_float-D50_2deg.xml
+++ b/Testing/PCC/XYZ_float-D50_2deg.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.964245565128246" Y="1.00000000" Z="0.824679094091967"/>
     </PCSIlluminant>

--- a/Testing/PCC/XYZ_float-D65_2deg-MAT.xml
+++ b/Testing/PCC/XYZ_float-D65_2deg-MAT.xml
@@ -11,7 +11,7 @@
     <CreationDateTime>now</CreationDateTime>
     <ProfileFlags EmbeddedInFile="true" UseWithEmbeddedDataOnly="false"/>
     <DeviceAttributes ReflectiveOrTransparency="reflective" GlossyOrMatte="glossy" MediaPolarity="positive" MediaColour="colour"/>
-    <RenderingIntent>Absolute Coloriemtric</RenderingIntent>
+    <RenderingIntent>Absolute Colorimetric</RenderingIntent>
     <PCSIlluminant>
       <XYZNumber X="0.950429662109893" Y="1.00000000" Z="1.088800568050674"/>
     </PCSIlluminant>


### PR DESCRIPTION
The issue is present throughout the xmls in this repo and is visible in the xmls published at the [iccMAX Profiles page](https://www.color.org/iccmax/profiles/index.xalter).