### PR TITLE
IccXML/CmdLine | Fixup Xcode SubProject Folders, Address Relative Path Issues, Build Script for Release + Debug

### DIFF
--- a/IccXML/CmdLine/IccFromXml/IccFromXml.xcodeproj/project.pbxproj
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.xcodeproj/project.pbxproj
@@ -7,22 +7,9 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */ = {
+		0D30941A617747D880E30805 /* ZERO_CHECK */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
-			buildPhases = (
-				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
-			);
-			dependencies = (
-				F5480FD0B0A84C77934A9037 /* PBXTargetDependency */,
-				8B7DFF8C11374DDA87445254 /* PBXTargetDependency */,
-			);
-			name = ALL_BUILD;
-			productName = ALL_BUILD;
-		};
-		3411FAD0C406493487491837 /* ZERO_CHECK */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
+			buildConfigurationList = 7CC5BAD081BF4386875775B5 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
 			buildPhases = (
 				5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */,
 			);
@@ -31,76 +18,88 @@
 			name = ZERO_CHECK;
 			productName = ZERO_CHECK;
 		};
+		92CEB7CB4D314135A05C7FE7 /* ALL_BUILD */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 4A29AAC750AE4860863B3A71 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
+			buildPhases = (
+				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
+			);
+			dependencies = (
+				CF2F4DC06D414985854724DD /* PBXTargetDependency */,
+				A374F09DBAE0449CAFD56C81 /* PBXTargetDependency */,
+			);
+			name = ALL_BUILD;
+			productName = ALL_BUILD;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-	60493C99C20A488A9645C356 /* IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */; };
-	713F6E42ABF94FEBAA9DA4CC /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */; };
+		0BCEEDD1600A4DD59A0D6F54 /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = 8465DD5D7FE64EA2BD808C00 /* CMakeLists.txt */; };
+		D865EEC9DC2E42058938EF14 /* IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = B59C30EF3E1C4821B2252F76 /* IccFromXml.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildStyle section */
-		4E651F165EDD4BEC9AC17500 /* Release */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = Release;
-		};
-		9AEDED2F2422459ABDC7E33F /* Debug */ = {
+		694D7F66A6A54E9893DDDF78 /* Debug */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = Debug;
 		};
-		F106AE83021243D2947F61BB /* MinSizeRel */ = {
+		871D081C97B54B9FA5DCBC87 /* MinSizeRel */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = MinSizeRel;
 		};
-		FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */ = {
+		9862084ADC7C4B789DE682EB /* RelWithDebInfo */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = RelWithDebInfo;
 		};
+		BD5FB2D95CE34E638968145D /* Release */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = Release;
+		};
 /* End PBXBuildStyle section */
 
 /* Begin PBXContainerItemProxy section */
-		817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */ = {
+		0DE149F9E918408691A6B419 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			containerPortal = 293BC55142D54BEFB7266791 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3411FAD0C406493487491837;
+			remoteGlobalIDString = 0D30941A617747D880E30805;
 			remoteInfo = ZERO_CHECK;
 		};
-		D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */ = {
+		24310A7ACF0847CD8913993C /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			containerPortal = 293BC55142D54BEFB7266791 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3411FAD0C406493487491837;
+			remoteGlobalIDString = 0D30941A617747D880E30805;
 			remoteInfo = ZERO_CHECK;
 		};
-		EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */ = {
+		CABD9CE835F4447FA2119714 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			containerPortal = 293BC55142D54BEFB7266791 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0849225D50C7465FA3475BAB;
+			remoteGlobalIDString = 81F0E24F351B4D538BAFBD2B;
 			remoteInfo = iccFromXml;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		A27CC4AEECD7422AB7C96F37 /* iccFromXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccFromXml; sourceTree = BUILT_PRODUCTS_DIR; };
-		A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
-		C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
+		8465DD5D7FE64EA2BD808C00 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
+		B59C30EF3E1C4821B2252F76 /* IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		72494E5A03644528AD44602E /* Frameworks */ = {
+		5397B6467F11453CB50466FF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -110,119 +109,119 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2802CDAFC8C04419AA6B39B4 /* Resources */ = {
+		27F71B4B76D2458E9C89DD9E = {
 			isa = PBXGroup;
 			children = (
+				DB11DF7A09E64DE9808E76F3 /* iccFromXml */,
+				A8061D193FE24C92AECA9326 /* ALL_BUILD */,
+				DED48722702F45AAB1BB531C /* Products */,
+				604BC972C63B4F56A8C88431 /* Frameworks */,
+				9CD67E4C35EC478EBA0E281C /* Resources */,
 			);
-			name = Resources;
 			sourceTree = "<group>";
 		};
-		355600AF39424A1EBBE1F18E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A27CC4AEECD7422AB7C96F37 /* iccFromXml */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		3C7151C6DE4440EC87CC158F /* Source Files */ = {
-			isa = PBXGroup;
-			children = (
-				A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */,
-			);
-			name = "Source Files";
-			sourceTree = "<group>";
-		};
-		3FC12FCAF8FB439D9EC19F19 /* Frameworks */ = {
+		604BC972C63B4F56A8C88431 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		43EC4EBC399C42D79CFEFDB4 /* iccFromXml */ = {
-			isa = PBXGroup;
-			children = (
-				3C7151C6DE4440EC87CC158F /* Source Files */,
-				C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */,
-			);
-			name = iccFromXml;
-			sourceTree = "<group>";
-		};
-		8F94EBF8105949008CA203D2 = {
-			isa = PBXGroup;
-			children = (
-				43EC4EBC399C42D79CFEFDB4 /* iccFromXml */,
-				F96B2AB09EC841B7B3EB073E /* ALL_BUILD */,
-				355600AF39424A1EBBE1F18E /* Products */,
-				3FC12FCAF8FB439D9EC19F19 /* Frameworks */,
-				2802CDAFC8C04419AA6B39B4 /* Resources */,
-			);
-			sourceTree = "<group>";
-		};
-		A5958533200D469E91CDE119 /* CMake Rules */ = {
+		6AA518DD69F649078F0F452E /* CMake Rules */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = "CMake Rules";
 			sourceTree = "<group>";
 		};
-		F96B2AB09EC841B7B3EB073E /* ALL_BUILD */ = {
+		9CD67E4C35EC478EBA0E281C /* Resources */ = {
 			isa = PBXGroup;
 			children = (
-				A5958533200D469E91CDE119 /* CMake Rules */,
-				CAA076C4D5824AC39CFB7463 /* CMakeLists.txt */,
+			);
+			name = Resources;
+			sourceTree = "<group>";
+		};
+		A8061D193FE24C92AECA9326 /* ALL_BUILD */ = {
+			isa = PBXGroup;
+			children = (
+				6AA518DD69F649078F0F452E /* CMake Rules */,
+				DDF0ED107AA54D3AAF3E11B1 /* CMakeLists.txt */,
 			);
 			name = ALL_BUILD;
+			sourceTree = "<group>";
+		};
+		B785AD3E1CF34ACA8A1CD0C9 /* Source Files */ = {
+			isa = PBXGroup;
+			children = (
+				B59C30EF3E1C4821B2252F76 /* IccFromXml.cpp */,
+			);
+			name = "Source Files";
+			sourceTree = "<group>";
+		};
+		DB11DF7A09E64DE9808E76F3 /* iccFromXml */ = {
+			isa = PBXGroup;
+			children = (
+				B785AD3E1CF34ACA8A1CD0C9 /* Source Files */,
+				8465DD5D7FE64EA2BD808C00 /* CMakeLists.txt */,
+			);
+			name = iccFromXml;
+			sourceTree = "<group>";
+		};
+		DED48722702F45AAB1BB531C /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F01777EC56F24F42ACB9A80C /* iccFromXml */,
+			);
+			name = Products;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		0849225D50C7465FA3475BAB /* iccFromXml */ = {
+		81F0E24F351B4D538BAFBD2B /* iccFromXml */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */;
+			buildConfigurationList = D6FAB04BCD75446DA4C0A42D /* Build configuration list for PBXNativeTarget "iccFromXml" */;
 			buildPhases = (
-				21DEDFAA4F1046CB95DC78A3 /* Sources */,
-				72494E5A03644528AD44602E /* Frameworks */,
+				0BB680BD982348ACA5B1BA6B /* Sources */,
+				5397B6467F11453CB50466FF /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */,
+				F77006585B8543AE95D3C514 /* PBXTargetDependency */,
 			);
 			name = iccFromXml;
 			productName = iccFromXml;
-			productReference = A27CC4AEECD7422AB7C96F37 /* iccFromXml */;
+			productReference = F01777EC56F24F42ACB9A80C /* iccFromXml */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		971E2AB583DA413F945C8805 /* Project object */ = {
+		293BC55142D54BEFB7266791 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1540;
 			};
-			buildConfigurationList = 2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */;
+			buildConfigurationList = 2120915E7EA44E04999C2523 /* Build configuration list for PBXProject "IccFromXml" */;
 			buildSettings = {
 			};
 			buildStyles = (
-				9AEDED2F2422459ABDC7E33F /* Debug */,
-				4E651F165EDD4BEC9AC17500 /* Release */,
-				F106AE83021243D2947F61BB /* MinSizeRel */,
-				FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */,
+				694D7F66A6A54E9893DDDF78 /* Debug */,
+				BD5FB2D95CE34E638968145D /* Release */,
+				871D081C97B54B9FA5DCBC87 /* MinSizeRel */,
+				9862084ADC7C4B789DE682EB /* RelWithDebInfo */,
 			);
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 0;
-			mainGroup = 8F94EBF8105949008CA203D2;
+			mainGroup = 27F71B4B76D2458E9C89DD9E;
 			projectDirPath = .;
 			projectRoot = "";
 			targets = (
-				1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */,
-				3411FAD0C406493487491837 /* ZERO_CHECK */,
-				0849225D50C7465FA3475BAB /* iccFromXml */,
+				92CEB7CB4D314135A05C7FE7 /* ALL_BUILD */,
+				0D30941A617747D880E30805 /* ZERO_CHECK */,
+				81F0E24F351B4D538BAFBD2B /* iccFromXml */,
 			);
 		};
 /* End PBXProject section */
@@ -238,27 +237,25 @@
 			);
 			name = "Generate CMakeFiles/ALL_BUILD";
 			outputPaths = (
-"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
-			);
+"IccFromXml/CMakeFiles/ALL_BUILD"			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-SRCROOT=$(pwd)
-if [ \"$CONFIGURATION\" = \"Debug\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Debug\"; then :
+  cd IccXML/CmdLine/IccFromXml
+  echo Build\\ all\\ projects
 fi
-if [ \"$CONFIGURATION\" = \"Release\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Release\"; then :
+  cd IccXML/CmdLine/IccFromXml
+  echo Build\\ all\\ projects
 fi
-if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
+  cd IccXML/CmdLine/IccFromXml
+  echo Build\\ all\\ projects
 fi
-if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
+  cd IccXML/CmdLine/IccFromXml
+  echo Build\\ all\\ projects
 fi
 ";
 			showEnvVarsInLog = 0;
@@ -278,8 +275,7 @@ fi
 exit 0";
 			showEnvVarsInLog = 0;
 		};
-/* Begin PBXShellScriptBuildPhase section */
-		250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */ = {
+		5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -287,29 +283,27 @@ exit 0";
 			);
 			inputPaths = (
 			);
-			name = "Generate CMakeFiles/ALL_BUILD";
+			name = "Generate CMakeFiles/ZERO_CHECK";
 			outputPaths = (
-"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
-			);
+"IccFromXml/CMakeFiles/ZERO_CHECK"			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-SRCROOT=$(pwd)
-if [ \"$CONFIGURATION\" = \"Debug\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Debug\"; then :
+  cd IccXML/CmdLine/IccFromXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
 fi
-if [ \"$CONFIGURATION\" = \"Release\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Release\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
 fi
-if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
 fi
-if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
 fi
 ";
 			showEnvVarsInLog = 0;
@@ -332,42 +326,102 @@ exit 0";
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		21DEDFAA4F1046CB95DC78A3 /* Sources */ = {
+		0BB680BD982348ACA5B1BA6B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-60493C99C20A488A9645C356 /* ../IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
+				D865EEC9DC2E42058938EF14 /* ../../../IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */ = {
+		A374F09DBAE0449CAFD56C81 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
-			targetProxy = 817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */;
+			target = 0D30941A617747D880E30805 /* ZERO_CHECK */;
+			targetProxy = 24310A7ACF0847CD8913993C /* PBXContainerItemProxy */;
 		};
-		8B7DFF8C11374DDA87445254 /* PBXTargetDependency */ = {
+		CF2F4DC06D414985854724DD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 0849225D50C7465FA3475BAB /* iccFromXml */;
-			targetProxy = EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */;
+			target = 81F0E24F351B4D538BAFBD2B /* iccFromXml */;
+			targetProxy = CABD9CE835F4447FA2119714 /* PBXContainerItemProxy */;
 		};
-		F5480FD0B0A84C77934A9037 /* PBXTargetDependency */ = {
+		F77006585B8543AE95D3C514 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
-			targetProxy = D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */;
+			target = 0D30941A617747D880E30805 /* ZERO_CHECK */;
+			targetProxy = 0DE149F9E918408691A6B419 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		006A88015E504B0E83FD58DE /* RelWithDebInfo */ = {
+		10E80300465A4CB89C34F00F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+		12631C86EB844B549A40D704 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		12C72A5F061741A38B3B0274 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		1A1B3CDF37FB42F99FDE63A8 /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/RelWithDebInfo";
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -375,83 +429,63 @@ exit 0";
 				GCC_OPTIMIZATION_LEVEL = 2;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../..","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
 				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = RelWithDebInfo;
 		};
-		0905BB31542547E1BD5EA790 /* RelWithDebInfo */ = {
+		1FFE68545D9C4E83A70412ED /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
+				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		15BBFE118EE545D5A94D2295 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		24AF7FAFD05F43FA87387EB3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = Release;
 		};
-		2D7E84543EB34209BA26C2A4 /* MinSizeRel */ = {
+		2E6FB1A37EBE402B98CE55E2 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
+			};
+			name = RelWithDebInfo;
+		};
+		43FB2D46B01845D5AA84C94D /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -468,37 +502,26 @@ exit 0";
 				SECTORDER_FLAGS = "";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		4B157568EAD3438EB51C9270 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
 			};
 			name = MinSizeRel;
 		};
-		3AFA782460FF42EBAD7FDE09 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
-			};
-			name = Release;
-		};
-		49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
-			};
-			name = RelWithDebInfo;
-		};
-/* Begin XCBuildConfiguration section */
-		50EA0E9AD6554940822C6F5D /* Debug */ = {
+		5460E0E70C5046B3AC3CB6E6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Debug";
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -506,75 +529,32 @@ exit 0";
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../../../IccProfLib",
-					"$(PROJECT_DIR)/../..",
-					"$(PROJECT_DIR)/../../IccLibXML",
-					"$(inherited)"
-				);
+				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../../../IccProfLib",
-					"$(PROJECT_DIR)/../..",
-					"$(PROJECT_DIR)/../../IccLibXML",
-					"$(inherited)"
-				);
-				LIBRARY_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
-					"$(PROJECT_DIR)/../../../Build/IccProfLib",
-					"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
-					"$(PROJECT_DIR)/../../../Build/IccXML",
-					"$(inherited)"
-				);
+				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CPLUSPLUSFLAGS = "   ";
-				OTHER_LDFLAGS = (
-					" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
-					"-lIccProfLib2.2",
-					"-lIccXML2.2",
-					"$(inherited)"
-				);
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = Debug;
 		};
-/* End XCBuildConfiguration section */
-83073211A6EE44CFB2DA3A3F /* MinSizeRel */ = {
-	isa = XCBuildConfiguration;
-	buildSettings = {
-		ALWAYS_SEARCH_USER_PATHS = NO;
-		ARCHS = x86_64;
-		COMBINE_HIDPI_IMAGES = YES;
-		CONFIGURATION_BUILD_DIR = "MinSizeRel";
-		EXECUTABLE_PREFIX = "";
-		EXECUTABLE_SUFFIX = "";
-		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-		GCC_OPTIMIZATION_LEVEL = s;
-		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-		HEADER_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../IccProfLib", "$(PROJECT_DIR)/../..", "$(PROJECT_DIR)/../../IccLibXML", "$(inherited)");
-		INSTALL_PATH = "";
-		LD_RUNPATH_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
-		LIBRARY_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
-		ONLY_ACTIVE_ARCH = NO;
-		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-		OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
-		OTHER_REZFLAGS = "";
-		PRODUCT_NAME = iccFromXml;
-		SECTORDER_FLAGS = "";
-		TARGET_TEMP_DIR = "$(PROJECT_DIR)/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-		USE_HEADERMAP = NO;
-		WARNING_CFLAGS = ("$(inherited)");
-	};
-	name = MinSizeRel;
-};
-		6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */ = {
+		5BC485B57BBE486289E23E95 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Debug;
+		};
+		63399F3ED95E41D8A80DB29F /* MinSizeRel */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -594,16 +574,37 @@ exit 0";
 			};
 			name = MinSizeRel;
 		};
-		75805ECF690B472E804707F7 /* Debug */ = {
+		6C975839112748EB9192C424 /* MinSizeRel */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SYMROOT = "$(PROJECT_DIR)/build";
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = iccFromXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
 			};
-			name = Debug;
+			name = MinSizeRel;
 		};
-		794243A7B31541E08DC890FB /* Release */ = {
+		81D58E4FF631462E8C9FEBB3 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -616,14 +617,44 @@ exit 0";
 				INSTALL_PATH = "";
 				OTHER_LDFLAGS = ("","$(inherited)");
 				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+		999BF21F6C204CF5AC691CEB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
 				SECTORDER_FLAGS = "";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = Release;
 		};
-		C5AB712B1F4847769A717E3F /* Debug */ = {
+		A1254BECCBAF46028448E18B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Release;
+		};
+		F1B60928605347BDA1BC6293 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -643,134 +674,54 @@ exit 0";
 			};
 			name = Debug;
 		};
-		DB4D0FBC109F4DCF8958010E /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "$(PROJECT_DIR)/build";
-			};
-			name = MinSizeRel;
-		};
-		E4BCD06E442943BDBA6E5671 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-E9B85C98251F448AA762F198 /* Release */ = {
-	isa = XCBuildConfiguration;
-	buildSettings = {
-		ALWAYS_SEARCH_USER_PATHS = NO;
-		ARCHS = x86_64;
-		COMBINE_HIDPI_IMAGES = YES;
-		CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Release";
-		EXECUTABLE_PREFIX = "";
-		EXECUTABLE_SUFFIX = "";
-		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-		GCC_OPTIMIZATION_LEVEL = 3;
-		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-		HEADER_SEARCH_PATHS = (
-			"$(PROJECT_DIR)/../../../IccProfLib",
-			"$(PROJECT_DIR)/../..",
-			"$(PROJECT_DIR)/../../IccLibXML",
-			"$(inherited)"
-		);
-		INSTALL_PATH = "";
-		LD_RUNPATH_SEARCH_PATHS = (
-			"$(PROJECT_DIR)/../../../Build/IccProfLib",
-			"$(PROJECT_DIR)/../../../Build/IccXML",
-			"$(inherited)"
-		);
-		LIBRARY_SEARCH_PATHS = (
-			"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
-			"$(PROJECT_DIR)/../../../Build/IccProfLib",
-			"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
-			"$(PROJECT_DIR)/../../../Build/IccXML",
-			"$(inherited)"
-		);
-		ONLY_ACTIVE_ARCH = NO;
-		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-		OTHER_LDFLAGS = (
-			" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
-			"-lIccProfLib2.2",
-			"-lIccXML2.2",
-			"$(inherited)"
-		);
-		OTHER_REZFLAGS = "";
-		PRODUCT_NAME = iccFromXml;
-		SECTORDER_FLAGS = "";
-		TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-		USE_HEADERMAP = NO;
-		WARNING_CFLAGS = ("$(inherited)");
-	};
-	name = Release;
-};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
+		2120915E7EA44E04999C2523 /* Build configuration list for PBXProject "IccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E4BCD06E442943BDBA6E5671 /* Debug */,
-				24AF7FAFD05F43FA87387EB3 /* Release */,
-				6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */,
-				0905BB31542547E1BD5EA790 /* RelWithDebInfo */,
+				5BC485B57BBE486289E23E95 /* Debug */,
+				A1254BECCBAF46028448E18B /* Release */,
+				4B157568EAD3438EB51C9270 /* MinSizeRel */,
+				2E6FB1A37EBE402B98CE55E2 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */ = {
+		4A29AAC750AE4860863B3A71 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				75805ECF690B472E804707F7 /* Debug */,
-				3AFA782460FF42EBAD7FDE09 /* Release */,
-				DB4D0FBC109F4DCF8958010E /* MinSizeRel */,
-				49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */,
+				F1B60928605347BDA1BC6293 /* Debug */,
+				10E80300465A4CB89C34F00F /* Release */,
+				12C72A5F061741A38B3B0274 /* MinSizeRel */,
+				43FB2D46B01845D5AA84C94D /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
+		7CC5BAD081BF4386875775B5 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C5AB712B1F4847769A717E3F /* Debug */,
-				794243A7B31541E08DC890FB /* Release */,
-				2D7E84543EB34209BA26C2A4 /* MinSizeRel */,
-				15BBFE118EE545D5A94D2295 /* RelWithDebInfo */,
+				81D58E4FF631462E8C9FEBB3 /* Debug */,
+				999BF21F6C204CF5AC691CEB /* Release */,
+				63399F3ED95E41D8A80DB29F /* MinSizeRel */,
+				12631C86EB844B549A40D704 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
+		D6FAB04BCD75446DA4C0A42D /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				50EA0E9AD6554940822C6F5D /* Debug */,
-				E9B85C98251F448AA762F198 /* Release */,
-				6573C4FE7C584052A79F126E /* MinSizeRel */,
-				006A88015E504B0E83FD58DE /* RelWithDebInfo */,
+				5460E0E70C5046B3AC3CB6E6 /* Debug */,
+				1FFE68545D9C4E83A70412ED /* Release */,
+				6C975839112748EB9192C424 /* MinSizeRel */,
+				1A1B3CDF37FB42F99FDE63A8 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 971E2AB583DA413F945C8805 /* Project object */;
+	rootObject = 293BC55142D54BEFB7266791 /* Project object */;
 }

--- a/IccXML/CmdLine/IccFromXml/IccFromXml.xcodeproj/project.pbxproj
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.xcodeproj/project.pbxproj
@@ -7,9 +7,22 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */ = {
+		1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 38AD401FDBF140D1B3F96E9F /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
+			buildConfigurationList = 4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
+			buildPhases = (
+				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
+			);
+			dependencies = (
+				F5480FD0B0A84C77934A9037 /* PBXTargetDependency */,
+				8B7DFF8C11374DDA87445254 /* PBXTargetDependency */,
+			);
+			name = ALL_BUILD;
+			productName = ALL_BUILD;
+		};
+		3411FAD0C406493487491837 /* ZERO_CHECK */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
 			buildPhases = (
 				5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */,
 			);
@@ -18,49 +31,36 @@
 			name = ZERO_CHECK;
 			productName = ZERO_CHECK;
 		};
-		5EB18A24724C48C7B651960B /* ALL_BUILD */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = DD049895B1FD48B09B3E0D34 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
-			buildPhases = (
-				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
-			);
-			dependencies = (
-				9531E4BC65E6403591DBE014 /* PBXTargetDependency */,
-				C9544D9CFCCB45E79C3567ED /* PBXTargetDependency */,
-			);
-			name = ALL_BUILD;
-			productName = ALL_BUILD;
-		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		3A52826226084BBBAEC5DB87 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = 43AA16E09DA1496EB8DB836B /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */; };
-		B2BDFB789A8645F8A4CC20F3 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = E215DEE5144848639F9230E0 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */; };
+	60493C99C20A488A9645C356 /* IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */; };
+	713F6E42ABF94FEBAA9DA4CC /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildStyle section */
-		24B92395B8A745028A44FBCA /* MinSizeRel */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = MinSizeRel;
-		};
-		8C8B536A1A1748E8A442D9CA /* Release */ = {
+		4E651F165EDD4BEC9AC17500 /* Release */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = Release;
 		};
-		F245AE56F57D44BC87FB5A9B /* Debug */ = {
+		9AEDED2F2422459ABDC7E33F /* Debug */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = Debug;
 		};
-		F27C912E35864EC48CF9CFB4 /* RelWithDebInfo */ = {
+		F106AE83021243D2947F61BB /* MinSizeRel */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = MinSizeRel;
+		};
+		FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
@@ -70,38 +70,37 @@
 /* End PBXBuildStyle section */
 
 /* Begin PBXContainerItemProxy section */
-		4BA62E166B8D4AF58DE2B40B /* PBXContainerItemProxy */ = {
+		817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 3996D935F14246888414F70F /* Project object */;
+			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0CC2FEBBE143401CBCD314F6;
+			remoteGlobalIDString = 3411FAD0C406493487491837;
+			remoteInfo = ZERO_CHECK;
+		};
+		D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 3411FAD0C406493487491837;
+			remoteInfo = ZERO_CHECK;
+		};
+		EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0849225D50C7465FA3475BAB;
 			remoteInfo = iccFromXml;
-		};
-		8B911AEB436448C58788DD24 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 3996D935F14246888414F70F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4CFDD2EDB8F242AEB06EB480;
-			remoteInfo = ZERO_CHECK;
-		};
-		8C7045AA7A5F498E960A91D7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 3996D935F14246888414F70F /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 4CFDD2EDB8F242AEB06EB480;
-			remoteInfo = ZERO_CHECK;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		259990E9BDFA4DA4A28F1CE1 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		2DCE5A97943D47418C592C2D /* iccFromXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccFromXml; sourceTree = BUILT_PRODUCTS_DIR; };
-		43AA16E09DA1496EB8DB836B /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		E215DEE5144848639F9230E0 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
+		A27CC4AEECD7422AB7C96F37 /* iccFromXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccFromXml; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
+		C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		A450390911BB49598E83A812 /* Frameworks */ = {
+		72494E5A03644528AD44602E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -111,119 +110,119 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		0536B3D0FF1246ADB10D1309 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				2DCE5A97943D47418C592C2D /* iccFromXml */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		28EFE988C4094A12974BCA1F /* CMake Rules */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = "CMake Rules";
-			sourceTree = "<group>";
-		};
-		2A675F36E68C4708B4BC2F14 /* Resources */ = {
+		2802CDAFC8C04419AA6B39B4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		72EF81BDE45F46DAAF931BF9 /* ALL_BUILD */ = {
+		355600AF39424A1EBBE1F18E /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				28EFE988C4094A12974BCA1F /* CMake Rules */,
-				259990E9BDFA4DA4A28F1CE1 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */,
+				A27CC4AEECD7422AB7C96F37 /* iccFromXml */,
 			);
-			name = ALL_BUILD;
+			name = Products;
 			sourceTree = "<group>";
 		};
-		7FDAF74326DB4DBAB704E2F5 /* iccFromXml */ = {
+		3C7151C6DE4440EC87CC158F /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
-				82C388E0349E46298F9AF273 /* Source Files */,
-				43AA16E09DA1496EB8DB836B /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */,
-			);
-			name = iccFromXml;
-			sourceTree = "<group>";
-		};
-		82C388E0349E46298F9AF273 /* Source Files */ = {
-			isa = PBXGroup;
-			children = (
-				E215DEE5144848639F9230E0 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
+				A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */,
 			);
 			name = "Source Files";
 			sourceTree = "<group>";
 		};
-		C572060F98E34134912953E0 = {
-			isa = PBXGroup;
-			children = (
-				7FDAF74326DB4DBAB704E2F5 /* iccFromXml */,
-				72EF81BDE45F46DAAF931BF9 /* ALL_BUILD */,
-				0536B3D0FF1246ADB10D1309 /* Products */,
-				D8CCBDD8D9754E3DB5B91E12 /* Frameworks */,
-				2A675F36E68C4708B4BC2F14 /* Resources */,
-			);
-			sourceTree = "<group>";
-		};
-		D8CCBDD8D9754E3DB5B91E12 /* Frameworks */ = {
+		3FC12FCAF8FB439D9EC19F19 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		43EC4EBC399C42D79CFEFDB4 /* iccFromXml */ = {
+			isa = PBXGroup;
+			children = (
+				3C7151C6DE4440EC87CC158F /* Source Files */,
+				C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */,
+			);
+			name = iccFromXml;
+			sourceTree = "<group>";
+		};
+		8F94EBF8105949008CA203D2 = {
+			isa = PBXGroup;
+			children = (
+				43EC4EBC399C42D79CFEFDB4 /* iccFromXml */,
+				F96B2AB09EC841B7B3EB073E /* ALL_BUILD */,
+				355600AF39424A1EBBE1F18E /* Products */,
+				3FC12FCAF8FB439D9EC19F19 /* Frameworks */,
+				2802CDAFC8C04419AA6B39B4 /* Resources */,
+			);
+			sourceTree = "<group>";
+		};
+		A5958533200D469E91CDE119 /* CMake Rules */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = "CMake Rules";
+			sourceTree = "<group>";
+		};
+		F96B2AB09EC841B7B3EB073E /* ALL_BUILD */ = {
+			isa = PBXGroup;
+			children = (
+				A5958533200D469E91CDE119 /* CMake Rules */,
+				CAA076C4D5824AC39CFB7463 /* CMakeLists.txt */,
+			);
+			name = ALL_BUILD;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		0CC2FEBBE143401CBCD314F6 /* iccFromXml */ = {
+		0849225D50C7465FA3475BAB /* iccFromXml */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 37A1497B7CDE4DC5B9697916 /* Build configuration list for PBXNativeTarget "iccFromXml" */;
+			buildConfigurationList = C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */;
 			buildPhases = (
-				C1F34EE727E144FBB80795B5 /* Sources */,
-				A450390911BB49598E83A812 /* Frameworks */,
+				21DEDFAA4F1046CB95DC78A3 /* Sources */,
+				72494E5A03644528AD44602E /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				489519AD71814FFB9A7FD8E4 /* PBXTargetDependency */,
+				3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */,
 			);
 			name = iccFromXml;
 			productName = iccFromXml;
-			productReference = 2DCE5A97943D47418C592C2D /* iccFromXml */;
+			productReference = A27CC4AEECD7422AB7C96F37 /* iccFromXml */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		3996D935F14246888414F70F /* Project object */ = {
+		971E2AB583DA413F945C8805 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1540;
 			};
-			buildConfigurationList = 106F549FA0E440E186690515 /* Build configuration list for PBXProject "IccFromXml" */;
+			buildConfigurationList = 2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */;
 			buildSettings = {
 			};
 			buildStyles = (
-				F245AE56F57D44BC87FB5A9B /* Debug */,
-				8C8B536A1A1748E8A442D9CA /* Release */,
-				24B92395B8A745028A44FBCA /* MinSizeRel */,
-				F27C912E35864EC48CF9CFB4 /* RelWithDebInfo */,
+				9AEDED2F2422459ABDC7E33F /* Debug */,
+				4E651F165EDD4BEC9AC17500 /* Release */,
+				F106AE83021243D2947F61BB /* MinSizeRel */,
+				FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */,
 			);
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 0;
-			mainGroup = C572060F98E34134912953E0;
+			mainGroup = 8F94EBF8105949008CA203D2;
 			projectDirPath = .;
 			projectRoot = "";
 			targets = (
-				5EB18A24724C48C7B651960B /* ALL_BUILD */,
-				4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */,
-				0CC2FEBBE143401CBCD314F6 /* iccFromXml */,
+				1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */,
+				3411FAD0C406493487491837 /* ZERO_CHECK */,
+				0849225D50C7465FA3475BAB /* iccFromXml */,
 			);
 		};
 /* End PBXProject section */
@@ -239,25 +238,27 @@
 			);
 			name = "Generate CMakeFiles/ALL_BUILD";
 			outputPaths = (
-"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"			);
+"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-if test \"$CONFIGURATION\" = \"Debug\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  echo Build\\ all\\ projects
+SRCROOT=$(pwd)
+if [ \"$CONFIGURATION\" = \"Debug\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"Release\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  echo Build\\ all\\ projects
+if [ \"$CONFIGURATION\" = \"Release\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  echo Build\\ all\\ projects
+if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  echo Build\\ all\\ projects
+if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
 ";
 			showEnvVarsInLog = 0;
@@ -277,7 +278,8 @@ fi
 exit 0";
 			showEnvVarsInLog = 0;
 		};
-		5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */ = {
+/* Begin PBXShellScriptBuildPhase section */
+		250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -285,27 +287,29 @@ exit 0";
 			);
 			inputPaths = (
 			);
-			name = "Generate CMakeFiles/ZERO_CHECK";
+			name = "Generate CMakeFiles/ALL_BUILD";
 			outputPaths = (
-"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeFiles/ZERO_CHECK"			);
+"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-if test \"$CONFIGURATION\" = \"Debug\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
+SRCROOT=$(pwd)
+if [ \"$CONFIGURATION\" = \"Debug\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"Release\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
+if [ \"$CONFIGURATION\" = \"Release\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
+if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
+if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
 ";
 			showEnvVarsInLog = 0;
@@ -328,252 +332,42 @@ exit 0";
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		C1F34EE727E144FBB80795B5 /* Sources */ = {
+		21DEDFAA4F1046CB95DC78A3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B2BDFB789A8645F8A4CC20F3 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
+60493C99C20A488A9645C356 /* ../IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		489519AD71814FFB9A7FD8E4 /* PBXTargetDependency */ = {
+		3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */;
-			targetProxy = 8C7045AA7A5F498E960A91D7 /* PBXContainerItemProxy */;
+			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
+			targetProxy = 817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */;
 		};
-		9531E4BC65E6403591DBE014 /* PBXTargetDependency */ = {
+		8B7DFF8C11374DDA87445254 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 0CC2FEBBE143401CBCD314F6 /* iccFromXml */;
-			targetProxy = 4BA62E166B8D4AF58DE2B40B /* PBXContainerItemProxy */;
+			target = 0849225D50C7465FA3475BAB /* iccFromXml */;
+			targetProxy = EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */;
 		};
-		C9544D9CFCCB45E79C3567ED /* PBXTargetDependency */ = {
+		F5480FD0B0A84C77934A9037 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */;
-			targetProxy = 8B911AEB436448C58788DD24 /* PBXContainerItemProxy */;
+			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
+			targetProxy = D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		19BDF8E1DF2D4A92BE4DD1C6 /* Debug */ = {
+		006A88015E504B0E83FD58DE /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/Debug";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
-				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "   ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccFromXml;
-				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-		1EEBDDFEDCC44DB48C2083C1 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
-			};
-			name = MinSizeRel;
-		};
-		2353D1ADA67A4222BCEE4D1E /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/Release";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 3;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
-				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccFromXml;
-				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Release;
-		};
-		2A298662DF8D40A9A1B60B3F /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		368087855D3840E3A4819848 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Release;
-		};
-		379FD76BC48B4BC5BEBC8712 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
-			};
-			name = RelWithDebInfo;
-		};
-		554F71402F974F07AE011A73 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = MinSizeRel;
-		};
-		605DF81087A1462F9A50F254 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = MinSizeRel;
-		};
-		67ADA187D15F41448B31FB9D /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		6E7F63F9EE8E4588A5B994F1 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
-			};
-			name = Release;
-		};
-		8951593DD18946599097EE72 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-		8BB7F65657254AB59213920C /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/RelWithDebInfo";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/RelWithDebInfo";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -581,23 +375,63 @@ exit 0";
 				GCC_OPTIMIZATION_LEVEL = 2;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				HEADER_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../..","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
 				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = RelWithDebInfo;
 		};
-		9051CB8792E64498A0A6D28F /* Release */ = {
+		0905BB31542547E1BD5EA790 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		15BBFE118EE545D5A94D2295 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		24AF7FAFD05F43FA87387EB3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -617,16 +451,209 @@ exit 0";
 			};
 			name = Release;
 		};
-		B870C6B0E7494073A1C58E2E /* Debug */ = {
+		2D7E84543EB34209BA26C2A4 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		3AFA782460FF42EBAD7FDE09 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
 				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Release;
+		};
+		49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = RelWithDebInfo;
+		};
+/* Begin XCBuildConfiguration section */
+		50EA0E9AD6554940822C6F5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Debug";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../IccProfLib",
+					"$(PROJECT_DIR)/../..",
+					"$(PROJECT_DIR)/../../IccLibXML",
+					"$(inherited)"
+				);
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../IccProfLib",
+					"$(PROJECT_DIR)/../..",
+					"$(PROJECT_DIR)/../../IccLibXML",
+					"$(inherited)"
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+					"$(PROJECT_DIR)/../../../Build/IccProfLib",
+					"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+					"$(PROJECT_DIR)/../../../Build/IccXML",
+					"$(inherited)"
+				);
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "   ";
+				OTHER_LDFLAGS = (
+					" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
+					"-lIccProfLib2.2",
+					"-lIccXML2.2",
+					"$(inherited)"
+				);
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = iccFromXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = Debug;
 		};
-		BC08E58CEED141C98EBF49D6 /* Debug */ = {
+/* End XCBuildConfiguration section */
+83073211A6EE44CFB2DA3A3F /* MinSizeRel */ = {
+	isa = XCBuildConfiguration;
+	buildSettings = {
+		ALWAYS_SEARCH_USER_PATHS = NO;
+		ARCHS = x86_64;
+		COMBINE_HIDPI_IMAGES = YES;
+		CONFIGURATION_BUILD_DIR = "MinSizeRel";
+		EXECUTABLE_PREFIX = "";
+		EXECUTABLE_SUFFIX = "";
+		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+		GCC_OPTIMIZATION_LEVEL = s;
+		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+		HEADER_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../IccProfLib", "$(PROJECT_DIR)/../..", "$(PROJECT_DIR)/../../IccLibXML", "$(inherited)");
+		INSTALL_PATH = "";
+		LD_RUNPATH_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
+		LIBRARY_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
+		ONLY_ACTIVE_ARCH = NO;
+		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+		OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+		OTHER_REZFLAGS = "";
+		PRODUCT_NAME = iccFromXml;
+		SECTORDER_FLAGS = "";
+		TARGET_TEMP_DIR = "$(PROJECT_DIR)/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+		USE_HEADERMAP = NO;
+		WARNING_CFLAGS = ("$(inherited)");
+	};
+	name = MinSizeRel;
+};
+		6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		75805ECF690B472E804707F7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SYMROOT = "$(PROJECT_DIR)/build";
+			};
+			name = Debug;
+		};
+		794243A7B31541E08DC890FB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+		C5AB712B1F4847769A717E3F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+		DB4D0FBC109F4DCF8958010E /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/build";
+			};
+			name = MinSizeRel;
+		};
+		E4BCD06E442943BDBA6E5671 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -646,84 +673,104 @@ exit 0";
 			};
 			name = Debug;
 		};
-		F3B10F6B41C541A793C9E1D7 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/MinSizeRel";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = s;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
-				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccFromXml;
-				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = MinSizeRel;
-		};
+E9B85C98251F448AA762F198 /* Release */ = {
+	isa = XCBuildConfiguration;
+	buildSettings = {
+		ALWAYS_SEARCH_USER_PATHS = NO;
+		ARCHS = x86_64;
+		COMBINE_HIDPI_IMAGES = YES;
+		CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Release";
+		EXECUTABLE_PREFIX = "";
+		EXECUTABLE_SUFFIX = "";
+		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+		GCC_OPTIMIZATION_LEVEL = 3;
+		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+		HEADER_SEARCH_PATHS = (
+			"$(PROJECT_DIR)/../../../IccProfLib",
+			"$(PROJECT_DIR)/../..",
+			"$(PROJECT_DIR)/../../IccLibXML",
+			"$(inherited)"
+		);
+		INSTALL_PATH = "";
+		LD_RUNPATH_SEARCH_PATHS = (
+			"$(PROJECT_DIR)/../../../Build/IccProfLib",
+			"$(PROJECT_DIR)/../../../Build/IccXML",
+			"$(inherited)"
+		);
+		LIBRARY_SEARCH_PATHS = (
+			"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+			"$(PROJECT_DIR)/../../../Build/IccProfLib",
+			"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+			"$(PROJECT_DIR)/../../../Build/IccXML",
+			"$(inherited)"
+		);
+		ONLY_ACTIVE_ARCH = NO;
+		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+		OTHER_LDFLAGS = (
+			" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
+			"-lIccProfLib2.2",
+			"-lIccXML2.2",
+			"$(inherited)"
+		);
+		OTHER_REZFLAGS = "";
+		PRODUCT_NAME = iccFromXml;
+		SECTORDER_FLAGS = "";
+		TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+		USE_HEADERMAP = NO;
+		WARNING_CFLAGS = ("$(inherited)");
+	};
+	name = Release;
+};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		106F549FA0E440E186690515 /* Build configuration list for PBXProject "IccFromXml" */ = {
+		08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B870C6B0E7494073A1C58E2E /* Debug */,
-				6E7F63F9EE8E4588A5B994F1 /* Release */,
-				1EEBDDFEDCC44DB48C2083C1 /* MinSizeRel */,
-				379FD76BC48B4BC5BEBC8712 /* RelWithDebInfo */,
+				E4BCD06E442943BDBA6E5671 /* Debug */,
+				24AF7FAFD05F43FA87387EB3 /* Release */,
+				6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */,
+				0905BB31542547E1BD5EA790 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		37A1497B7CDE4DC5B9697916 /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
+		2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				19BDF8E1DF2D4A92BE4DD1C6 /* Debug */,
-				2353D1ADA67A4222BCEE4D1E /* Release */,
-				F3B10F6B41C541A793C9E1D7 /* MinSizeRel */,
-				8BB7F65657254AB59213920C /* RelWithDebInfo */,
+				75805ECF690B472E804707F7 /* Debug */,
+				3AFA782460FF42EBAD7FDE09 /* Release */,
+				DB4D0FBC109F4DCF8958010E /* MinSizeRel */,
+				49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		38AD401FDBF140D1B3F96E9F /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
+		4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				BC08E58CEED141C98EBF49D6 /* Debug */,
-				9051CB8792E64498A0A6D28F /* Release */,
-				605DF81087A1462F9A50F254 /* MinSizeRel */,
-				67ADA187D15F41448B31FB9D /* RelWithDebInfo */,
+				C5AB712B1F4847769A717E3F /* Debug */,
+				794243A7B31541E08DC890FB /* Release */,
+				2D7E84543EB34209BA26C2A4 /* MinSizeRel */,
+				15BBFE118EE545D5A94D2295 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		DD049895B1FD48B09B3E0D34 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
+		C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				8951593DD18946599097EE72 /* Debug */,
-				368087855D3840E3A4819848 /* Release */,
-				554F71402F974F07AE011A73 /* MinSizeRel */,
-				2A298662DF8D40A9A1B60B3F /* RelWithDebInfo */,
+				50EA0E9AD6554940822C6F5D /* Debug */,
+				E9B85C98251F448AA762F198 /* Release */,
+				6573C4FE7C584052A79F126E /* MinSizeRel */,
+				006A88015E504B0E83FD58DE /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 3996D935F14246888414F70F /* Project object */;
+	rootObject = 971E2AB583DA413F945C8805 /* Project object */;
 }

--- a/IccXML/CmdLine/IccFromXml/IccFromXml.xcodeproj/project.pbxproj
+++ b/IccXML/CmdLine/IccFromXml/IccFromXml.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		0D30941A617747D880E30805 /* ZERO_CHECK */ = {
+		4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 7CC5BAD081BF4386875775B5 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
+			buildConfigurationList = 38AD401FDBF140D1B3F96E9F /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
 			buildPhases = (
 				5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */,
 			);
@@ -18,15 +18,15 @@
 			name = ZERO_CHECK;
 			productName = ZERO_CHECK;
 		};
-		92CEB7CB4D314135A05C7FE7 /* ALL_BUILD */ = {
+		5EB18A24724C48C7B651960B /* ALL_BUILD */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 4A29AAC750AE4860863B3A71 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
+			buildConfigurationList = DD049895B1FD48B09B3E0D34 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
 			buildPhases = (
 				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
 			);
 			dependencies = (
-				CF2F4DC06D414985854724DD /* PBXTargetDependency */,
-				A374F09DBAE0449CAFD56C81 /* PBXTargetDependency */,
+				9531E4BC65E6403591DBE014 /* PBXTargetDependency */,
+				C9544D9CFCCB45E79C3567ED /* PBXTargetDependency */,
 			);
 			name = ALL_BUILD;
 			productName = ALL_BUILD;
@@ -34,72 +34,74 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		0BCEEDD1600A4DD59A0D6F54 /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = 8465DD5D7FE64EA2BD808C00 /* CMakeLists.txt */; };
-		D865EEC9DC2E42058938EF14 /* IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = B59C30EF3E1C4821B2252F76 /* IccFromXml.cpp */; };
+		3A52826226084BBBAEC5DB87 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = 43AA16E09DA1496EB8DB836B /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */; };
+		B2BDFB789A8645F8A4CC20F3 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = E215DEE5144848639F9230E0 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildStyle section */
-		694D7F66A6A54E9893DDDF78 /* Debug */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = Debug;
-		};
-		871D081C97B54B9FA5DCBC87 /* MinSizeRel */ = {
+		24B92395B8A745028A44FBCA /* MinSizeRel */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = MinSizeRel;
 		};
-		9862084ADC7C4B789DE682EB /* RelWithDebInfo */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = RelWithDebInfo;
-		};
-		BD5FB2D95CE34E638968145D /* Release */ = {
+		8C8B536A1A1748E8A442D9CA /* Release */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = Release;
 		};
+		F245AE56F57D44BC87FB5A9B /* Debug */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = Debug;
+		};
+		F27C912E35864EC48CF9CFB4 /* RelWithDebInfo */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = RelWithDebInfo;
+		};
 /* End PBXBuildStyle section */
 
 /* Begin PBXContainerItemProxy section */
-		0DE149F9E918408691A6B419 /* PBXContainerItemProxy */ = {
+		4BA62E166B8D4AF58DE2B40B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 293BC55142D54BEFB7266791 /* Project object */;
+			containerPortal = 3996D935F14246888414F70F /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 0D30941A617747D880E30805;
-			remoteInfo = ZERO_CHECK;
-		};
-		24310A7ACF0847CD8913993C /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 293BC55142D54BEFB7266791 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0D30941A617747D880E30805;
-			remoteInfo = ZERO_CHECK;
-		};
-		CABD9CE835F4447FA2119714 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 293BC55142D54BEFB7266791 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 81F0E24F351B4D538BAFBD2B;
+			remoteGlobalIDString = 0CC2FEBBE143401CBCD314F6;
 			remoteInfo = iccFromXml;
+		};
+		8B911AEB436448C58788DD24 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3996D935F14246888414F70F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4CFDD2EDB8F242AEB06EB480;
+			remoteInfo = ZERO_CHECK;
+		};
+		8C7045AA7A5F498E960A91D7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 3996D935F14246888414F70F /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 4CFDD2EDB8F242AEB06EB480;
+			remoteInfo = ZERO_CHECK;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		8465DD5D7FE64EA2BD808C00 /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		B59C30EF3E1C4821B2252F76 /* IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
+		259990E9BDFA4DA4A28F1CE1 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
+		2DCE5A97943D47418C592C2D /* iccFromXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccFromXml; sourceTree = BUILT_PRODUCTS_DIR; };
+		43AA16E09DA1496EB8DB836B /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
+		E215DEE5144848639F9230E0 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		5397B6467F11453CB50466FF /* Frameworks */ = {
+		A450390911BB49598E83A812 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -109,119 +111,119 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		27F71B4B76D2458E9C89DD9E = {
+		0536B3D0FF1246ADB10D1309 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				DB11DF7A09E64DE9808E76F3 /* iccFromXml */,
-				A8061D193FE24C92AECA9326 /* ALL_BUILD */,
-				DED48722702F45AAB1BB531C /* Products */,
-				604BC972C63B4F56A8C88431 /* Frameworks */,
-				9CD67E4C35EC478EBA0E281C /* Resources */,
+				2DCE5A97943D47418C592C2D /* iccFromXml */,
 			);
+			name = Products;
 			sourceTree = "<group>";
 		};
-		604BC972C63B4F56A8C88431 /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		6AA518DD69F649078F0F452E /* CMake Rules */ = {
+		28EFE988C4094A12974BCA1F /* CMake Rules */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = "CMake Rules";
 			sourceTree = "<group>";
 		};
-		9CD67E4C35EC478EBA0E281C /* Resources */ = {
+		2A675F36E68C4708B4BC2F14 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		A8061D193FE24C92AECA9326 /* ALL_BUILD */ = {
+		72EF81BDE45F46DAAF931BF9 /* ALL_BUILD */ = {
 			isa = PBXGroup;
 			children = (
-				6AA518DD69F649078F0F452E /* CMake Rules */,
-				DDF0ED107AA54D3AAF3E11B1 /* CMakeLists.txt */,
+				28EFE988C4094A12974BCA1F /* CMake Rules */,
+				259990E9BDFA4DA4A28F1CE1 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */,
 			);
 			name = ALL_BUILD;
 			sourceTree = "<group>";
 		};
-		B785AD3E1CF34ACA8A1CD0C9 /* Source Files */ = {
+		7FDAF74326DB4DBAB704E2F5 /* iccFromXml */ = {
 			isa = PBXGroup;
 			children = (
-				B59C30EF3E1C4821B2252F76 /* IccFromXml.cpp */,
-			);
-			name = "Source Files";
-			sourceTree = "<group>";
-		};
-		DB11DF7A09E64DE9808E76F3 /* iccFromXml */ = {
-			isa = PBXGroup;
-			children = (
-				B785AD3E1CF34ACA8A1CD0C9 /* Source Files */,
-				8465DD5D7FE64EA2BD808C00 /* CMakeLists.txt */,
+				82C388E0349E46298F9AF273 /* Source Files */,
+				43AA16E09DA1496EB8DB836B /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeLists.txt */,
 			);
 			name = iccFromXml;
 			sourceTree = "<group>";
 		};
-		DED48722702F45AAB1BB531C /* Products */ = {
+		82C388E0349E46298F9AF273 /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
-				F01777EC56F24F42ACB9A80C /* iccFromXml */,
+				E215DEE5144848639F9230E0 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
 			);
-			name = Products;
+			name = "Source Files";
+			sourceTree = "<group>";
+		};
+		C572060F98E34134912953E0 = {
+			isa = PBXGroup;
+			children = (
+				7FDAF74326DB4DBAB704E2F5 /* iccFromXml */,
+				72EF81BDE45F46DAAF931BF9 /* ALL_BUILD */,
+				0536B3D0FF1246ADB10D1309 /* Products */,
+				D8CCBDD8D9754E3DB5B91E12 /* Frameworks */,
+				2A675F36E68C4708B4BC2F14 /* Resources */,
+			);
+			sourceTree = "<group>";
+		};
+		D8CCBDD8D9754E3DB5B91E12 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		81F0E24F351B4D538BAFBD2B /* iccFromXml */ = {
+		0CC2FEBBE143401CBCD314F6 /* iccFromXml */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = D6FAB04BCD75446DA4C0A42D /* Build configuration list for PBXNativeTarget "iccFromXml" */;
+			buildConfigurationList = 37A1497B7CDE4DC5B9697916 /* Build configuration list for PBXNativeTarget "iccFromXml" */;
 			buildPhases = (
-				0BB680BD982348ACA5B1BA6B /* Sources */,
-				5397B6467F11453CB50466FF /* Frameworks */,
+				C1F34EE727E144FBB80795B5 /* Sources */,
+				A450390911BB49598E83A812 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				F77006585B8543AE95D3C514 /* PBXTargetDependency */,
+				489519AD71814FFB9A7FD8E4 /* PBXTargetDependency */,
 			);
 			name = iccFromXml;
 			productName = iccFromXml;
-			productReference = F01777EC56F24F42ACB9A80C /* iccFromXml */;
+			productReference = 2DCE5A97943D47418C592C2D /* iccFromXml */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		293BC55142D54BEFB7266791 /* Project object */ = {
+		3996D935F14246888414F70F /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1540;
 			};
-			buildConfigurationList = 2120915E7EA44E04999C2523 /* Build configuration list for PBXProject "IccFromXml" */;
+			buildConfigurationList = 106F549FA0E440E186690515 /* Build configuration list for PBXProject "IccFromXml" */;
 			buildSettings = {
 			};
 			buildStyles = (
-				694D7F66A6A54E9893DDDF78 /* Debug */,
-				BD5FB2D95CE34E638968145D /* Release */,
-				871D081C97B54B9FA5DCBC87 /* MinSizeRel */,
-				9862084ADC7C4B789DE682EB /* RelWithDebInfo */,
+				F245AE56F57D44BC87FB5A9B /* Debug */,
+				8C8B536A1A1748E8A442D9CA /* Release */,
+				24B92395B8A745028A44FBCA /* MinSizeRel */,
+				F27C912E35864EC48CF9CFB4 /* RelWithDebInfo */,
 			);
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 0;
-			mainGroup = 27F71B4B76D2458E9C89DD9E;
+			mainGroup = C572060F98E34134912953E0;
 			projectDirPath = .;
 			projectRoot = "";
 			targets = (
-				92CEB7CB4D314135A05C7FE7 /* ALL_BUILD */,
-				0D30941A617747D880E30805 /* ZERO_CHECK */,
-				81F0E24F351B4D538BAFBD2B /* iccFromXml */,
+				5EB18A24724C48C7B651960B /* ALL_BUILD */,
+				4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */,
+				0CC2FEBBE143401CBCD314F6 /* iccFromXml */,
 			);
 		};
 /* End PBXProject section */
@@ -237,24 +239,24 @@
 			);
 			name = "Generate CMakeFiles/ALL_BUILD";
 			outputPaths = (
-"IccFromXml/CMakeFiles/ALL_BUILD"			);
+"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
 if test \"$CONFIGURATION\" = \"Debug\"; then :
-  cd IccXML/CmdLine/IccFromXml
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
   echo Build\\ all\\ projects
 fi
 if test \"$CONFIGURATION\" = \"Release\"; then :
-  cd IccXML/CmdLine/IccFromXml
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
   echo Build\\ all\\ projects
 fi
 if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
-  cd IccXML/CmdLine/IccFromXml
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
   echo Build\\ all\\ projects
 fi
 if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
-  cd IccXML/CmdLine/IccFromXml
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
   echo Build\\ all\\ projects
 fi
 ";
@@ -285,12 +287,12 @@ exit 0";
 			);
 			name = "Generate CMakeFiles/ZERO_CHECK";
 			outputPaths = (
-"IccFromXml/CMakeFiles/ZERO_CHECK"			);
+"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeFiles/ZERO_CHECK"			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
 if test \"$CONFIGURATION\" = \"Debug\"; then :
-  cd IccXML/CmdLine/IccFromXml
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml
   make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/CMakeScripts/ReRunCMake.make
 fi
 if test \"$CONFIGURATION\" = \"Release\"; then :
@@ -326,132 +328,98 @@ exit 0";
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		0BB680BD982348ACA5B1BA6B /* Sources */ = {
+		C1F34EE727E144FBB80795B5 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				D865EEC9DC2E42058938EF14 /* ../../../IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
+				B2BDFB789A8645F8A4CC20F3 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A374F09DBAE0449CAFD56C81 /* PBXTargetDependency */ = {
+		489519AD71814FFB9A7FD8E4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 0D30941A617747D880E30805 /* ZERO_CHECK */;
-			targetProxy = 24310A7ACF0847CD8913993C /* PBXContainerItemProxy */;
+			target = 4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */;
+			targetProxy = 8C7045AA7A5F498E960A91D7 /* PBXContainerItemProxy */;
 		};
-		CF2F4DC06D414985854724DD /* PBXTargetDependency */ = {
+		9531E4BC65E6403591DBE014 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 81F0E24F351B4D538BAFBD2B /* iccFromXml */;
-			targetProxy = CABD9CE835F4447FA2119714 /* PBXContainerItemProxy */;
+			target = 0CC2FEBBE143401CBCD314F6 /* iccFromXml */;
+			targetProxy = 4BA62E166B8D4AF58DE2B40B /* PBXContainerItemProxy */;
 		};
-		F77006585B8543AE95D3C514 /* PBXTargetDependency */ = {
+		C9544D9CFCCB45E79C3567ED /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 0D30941A617747D880E30805 /* ZERO_CHECK */;
-			targetProxy = 0DE149F9E918408691A6B419 /* PBXContainerItemProxy */;
+			target = 4CFDD2EDB8F242AEB06EB480 /* ZERO_CHECK */;
+			targetProxy = 8B911AEB436448C58788DD24 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		10E80300465A4CB89C34F00F /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Release;
-		};
-		12631C86EB844B549A40D704 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		12C72A5F061741A38B3B0274 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = MinSizeRel;
-		};
-		1A1B3CDF37FB42F99FDE63A8 /* RelWithDebInfo */ = {
+		19BDF8E1DF2D4A92BE4DD1C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/Debug";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 2;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
+				OTHER_CPLUSPLUSFLAGS = "   ";
 				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = RelWithDebInfo;
 		};
-		1FFE68545D9C4E83A70412ED /* Release */ = {
+<<<<<<< HEAD
+		0D0CEFB7D5684B9DBDB08CAC /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/build";
+			};
+			name = MinSizeRel;
+		};
+		1F2F8AAAD67A4D8AAEEF3592 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+=======
+		1EEBDDFEDCC44DB48C2083C1 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = MinSizeRel;
+		};
+		2353D1ADA67A4222BCEE4D1E /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/Release";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
@@ -459,33 +427,23 @@ exit 0";
 				GCC_OPTIMIZATION_LEVEL = 3;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
 				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = Release;
 		};
-		2E6FB1A37EBE402B98CE55E2 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
-			};
-			name = RelWithDebInfo;
-		};
-		43FB2D46B01845D5AA84C94D /* RelWithDebInfo */ = {
+		2A298662DF8D40A9A1B60B3F /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -505,56 +463,219 @@ exit 0";
 			};
 			name = RelWithDebInfo;
 		};
-		4B157568EAD3438EB51C9270 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
-			};
-			name = MinSizeRel;
-		};
-		5460E0E70C5046B3AC3CB6E6 /* Debug */ = {
+		368087855D3840E3A4819848 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "   ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_LDFLAGS = ("","$(inherited)");
 				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccFromXml;
+				PRODUCT_NAME = ALL_BUILD;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
-			name = Debug;
+			name = Release;
 		};
-		5BC485B57BBE486289E23E95 /* Debug */ = {
+		379FD76BC48B4BC5BEBC8712 /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
 				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = RelWithDebInfo;
+		};
+		554F71402F974F07AE011A73 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		605DF81087A1462F9A50F254 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+>>>>>>> InternationalColorConsortium/master
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+<<<<<<< HEAD
 			};
 			name = Debug;
 		};
-		63399F3ED95E41D8A80DB29F /* MinSizeRel */ = {
+		1EEBDDFEDCC44DB48C2083C1 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = MinSizeRel;
+		};
+		2353D1ADA67A4222BCEE4D1E /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/Release";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = iccFromXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		67ADA187D15F41448B31FB9D /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		6E7F63F9EE8E4588A5B994F1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Release;
+		};
+		2A298662DF8D40A9A1B60B3F /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		368087855D3840E3A4819848 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+		379FD76BC48B4BC5BEBC8712 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = RelWithDebInfo;
+		};
+		554F71402F974F07AE011A73 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		605DF81087A1462F9A50F254 /* MinSizeRel */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -574,13 +695,142 @@ exit 0";
 			};
 			name = MinSizeRel;
 		};
-		6C975839112748EB9192C424 /* MinSizeRel */ = {
+		67ADA187D15F41448B31FB9D /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		6E7F63F9EE8E4588A5B994F1 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Release;
+		};
+		8951593DD18946599097EE72 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+		8BB7F65657254AB59213920C /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/RelWithDebInfo";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 2;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = iccFromXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		9051CB8792E64498A0A6D28F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+		B870C6B0E7494073A1C58E2E /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Debug;
+		};
+		BC08E58CEED141C98EBF49D6 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+		F3B10F6B41C541A793C9E1D7 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/MinSizeRel";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
@@ -588,140 +838,70 @@ exit 0";
 				GCC_OPTIMIZATION_LEVEL = s;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../ ../../../IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME) ../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","../../../IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
 				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
 				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = MinSizeRel;
 		};
-		81D58E4FF631462E8C9FEBB3 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-		999BF21F6C204CF5AC691CEB /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Release;
-		};
-		A1254BECCBAF46028448E18B /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "../../../IccXML/CmdLine/IccFromXml/build";
-			};
-			name = Release;
-		};
-		F1B60928605347BDA1BC6293 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		2120915E7EA44E04999C2523 /* Build configuration list for PBXProject "IccFromXml" */ = {
+		106F549FA0E440E186690515 /* Build configuration list for PBXProject "IccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5BC485B57BBE486289E23E95 /* Debug */,
-				A1254BECCBAF46028448E18B /* Release */,
-				4B157568EAD3438EB51C9270 /* MinSizeRel */,
-				2E6FB1A37EBE402B98CE55E2 /* RelWithDebInfo */,
+				B870C6B0E7494073A1C58E2E /* Debug */,
+				6E7F63F9EE8E4588A5B994F1 /* Release */,
+				1EEBDDFEDCC44DB48C2083C1 /* MinSizeRel */,
+				379FD76BC48B4BC5BEBC8712 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		4A29AAC750AE4860863B3A71 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
+		37A1497B7CDE4DC5B9697916 /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F1B60928605347BDA1BC6293 /* Debug */,
-				10E80300465A4CB89C34F00F /* Release */,
-				12C72A5F061741A38B3B0274 /* MinSizeRel */,
-				43FB2D46B01845D5AA84C94D /* RelWithDebInfo */,
+				19BDF8E1DF2D4A92BE4DD1C6 /* Debug */,
+				2353D1ADA67A4222BCEE4D1E /* Release */,
+				F3B10F6B41C541A793C9E1D7 /* MinSizeRel */,
+				8BB7F65657254AB59213920C /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		7CC5BAD081BF4386875775B5 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
+		38AD401FDBF140D1B3F96E9F /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				81D58E4FF631462E8C9FEBB3 /* Debug */,
-				999BF21F6C204CF5AC691CEB /* Release */,
-				63399F3ED95E41D8A80DB29F /* MinSizeRel */,
-				12631C86EB844B549A40D704 /* RelWithDebInfo */,
+				BC08E58CEED141C98EBF49D6 /* Debug */,
+				9051CB8792E64498A0A6D28F /* Release */,
+				605DF81087A1462F9A50F254 /* MinSizeRel */,
+				67ADA187D15F41448B31FB9D /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		D6FAB04BCD75446DA4C0A42D /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
+		DD049895B1FD48B09B3E0D34 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				5460E0E70C5046B3AC3CB6E6 /* Debug */,
-				1FFE68545D9C4E83A70412ED /* Release */,
-				6C975839112748EB9192C424 /* MinSizeRel */,
-				1A1B3CDF37FB42F99FDE63A8 /* RelWithDebInfo */,
+				8951593DD18946599097EE72 /* Debug */,
+				368087855D3840E3A4819848 /* Release */,
+				554F71402F974F07AE011A73 /* MinSizeRel */,
+				2A298662DF8D40A9A1B60B3F /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 293BC55142D54BEFB7266791 /* Project object */;
+	rootObject = 3996D935F14246888414F70F /* Project object */;
 }

--- a/IccXML/CmdLine/IccFromXml/xnu_build_cmd_IccFromXml.zsh
+++ b/IccXML/CmdLine/IccFromXml/xnu_build_cmd_IccFromXml.zsh
@@ -1,0 +1,34 @@
+#!/bin/zsh
+
+echo "This Project is configured to manually build a command line tool, you must have already built and installed the dylibs...."
+
+# Project and configurations
+PROJECT="IccFromXml.xcodeproj"
+CONFIGURATIONS=("Debug" "Release")
+SCHEMES=("ALL_BUILD" "iccFromXml" "ZERO_CHECK")
+
+# Destination
+DESTINATION="platform=macOS,arch=x86_64"
+
+# Mark the build directory as created by the build system
+BUILD_DIR="$(pwd)/IccXML/CmdLine/IccFromXml/build"
+xattr -w com.apple.xcode.CreatedByBuildSystem true "$BUILD_DIR"
+
+# Function to build with a specific configuration and scheme
+build_project() {
+    local scheme=$1
+    local config=$2
+
+    echo "Building scheme '$scheme' with configuration '$config'..."
+    xcodebuild -project "$PROJECT" -scheme "$scheme" -configuration "$config" -destination "$DESTINATION" clean build
+}
+
+# Iterate over configurations and schemes
+for config in "${CONFIGURATIONS[@]}"; do
+    for scheme in "${SCHEMES[@]}"; do
+        build_project "$scheme" "$config"
+    done
+done
+
+echo "All builds completed."
+

--- a/IccXML/CmdLine/IccToXml/CMakeLists.txt
+++ b/IccXML/CmdLine/IccToXml/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.10)
 
 # Project setup
-project(IccToXML)
+project(IccToXml)
 
 # Set architecture and SDK path
 if(NOT CMAKE_OSX_ARCHITECTURES)
@@ -14,7 +14,7 @@ set(CMAKE_OSX_SYSROOT "${SDK_PATH}")
 # Include directories
 include_directories(
     "${CMAKE_SOURCE_DIR}/../../../IccProfLib"
-    "${CMAKE_SOURCE_DIR}/../../"
+    "${CMAKE_SOURCE_DIR}/../.."
     "${CMAKE_SOURCE_DIR}/../../IccLibXML"
 )
 
@@ -43,5 +43,3 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 # Add linker flags
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -v -Wl,-v")
-
-

--- a/IccXML/CmdLine/IccToXml/CMakeLists.txt
+++ b/IccXML/CmdLine/IccToXml/CMakeLists.txt
@@ -38,6 +38,18 @@ target_link_libraries(IccToXml
     IccXML2.2
 )
 
+# Set RPATH to locate the dynamic libraries
+set_target_properties(IccToXml PROPERTIES
+    INSTALL_RPATH "${CMAKE_SOURCE_DIR}/../../../Build/IccProfLib;${CMAKE_SOURCE_DIR}/../../../Build/IccXML"
+    BUILD_WITH_INSTALL_RPATH TRUE
+)
+
+# Set the executable output directory for both Debug and Release configurations
+set_target_properties(IccToXml PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY_DEBUG "${CMAKE_BINARY_DIR}/Debug"
+    RUNTIME_OUTPUT_DIRECTORY_RELEASE "${CMAKE_BINARY_DIR}/Release"
+)
+
 # Verbose compiler output
 set(CMAKE_VERBOSE_MAKEFILE ON)
 

--- a/IccXML/CmdLine/IccToXml/IccToXML.xcodeproj/project.pbxproj
+++ b/IccXML/CmdLine/IccToXml/IccToXML.xcodeproj/project.pbxproj
@@ -7,100 +7,101 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */ = {
+		6156AFFF05EF4745A09FB15D /* ZERO_CHECK */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
+			buildConfigurationList = 79B6EE6DE00548F0B7C0D8A1 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
 			buildPhases = (
-				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
-			);
-			dependencies = (
-				F5480FD0B0A84C77934A9037 /* PBXTargetDependency */,
-				8B7DFF8C11374DDA87445254 /* PBXTargetDependency */,
-			);
-			name = ALL_BUILD;
-			productName = ALL_BUILD;
-		};
-		3411FAD0C406493487491837 /* ZERO_CHECK */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
-			buildPhases = (
-				5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */,
+				4EE8C1BE3C86D4BB0CC13A0A /* Generate CMakeFiles/ZERO_CHECK */,
 			);
 			dependencies = (
 			);
 			name = ZERO_CHECK;
 			productName = ZERO_CHECK;
 		};
+		A870E0F59168450AB7955BFD /* ALL_BUILD */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 41E2965D435E4F6595251DF6 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
+			buildPhases = (
+				14A5F83B6D29791B56CE0898 /* Generate CMakeFiles/ALL_BUILD */,
+			);
+			dependencies = (
+				F8BBBEE7EA58456196421F8B /* PBXTargetDependency */,
+				AC667993240C4CDF9AE55BCA /* PBXTargetDependency */,
+			);
+			name = ALL_BUILD;
+			productName = ALL_BUILD;
+		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-	60493C99C20A488A9645C356 /* IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */; };
-	713F6E42ABF94FEBAA9DA4CC /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */; };
+		D110157AAC074692BD1CDFD0 /* IccToXml.cpp */ = {isa = PBXBuildFile; fileRef = 9F1A73B9F559435CB88C27C3 /* IccToXml.cpp */; };
+		ED383BBDA629417585AAF958 /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = AB185A867DDD4D88A63F2DE8 /* CMakeLists.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildStyle section */
-		4E651F165EDD4BEC9AC17500 /* Release */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = Release;
-		};
-		9AEDED2F2422459ABDC7E33F /* Debug */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = Debug;
-		};
-		F106AE83021243D2947F61BB /* MinSizeRel */ = {
+		10E4CEFBD6204CF5A7100CD3 /* MinSizeRel */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = MinSizeRel;
 		};
-		FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */ = {
+		679CA637460D4BB684E4F565 /* Release */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = Release;
+		};
+		72EC00AE80F6485083B6908A /* RelWithDebInfo */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = RelWithDebInfo;
 		};
+		A3F5B1BE70574220A7803536 /* Debug */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = Debug;
+		};
 /* End PBXBuildStyle section */
 
 /* Begin PBXContainerItemProxy section */
-		817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */ = {
+		319818F2D82D4EBE856BD28A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			containerPortal = 6A45B90AD63543428DA3A3AA /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3411FAD0C406493487491837;
+			remoteGlobalIDString = 3D15BBDF81A64CBB95C23721;
+			remoteInfo = IccToXml;
+		};
+		8C5113A127D94DD3A90DD525 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 6A45B90AD63543428DA3A3AA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 6156AFFF05EF4745A09FB15D;
 			remoteInfo = ZERO_CHECK;
 		};
-		D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */ = {
+		AD1FA1E5353C487AA4706CEB /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			containerPortal = 6A45B90AD63543428DA3A3AA /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 3411FAD0C406493487491837;
+			remoteGlobalIDString = 6156AFFF05EF4745A09FB15D;
 			remoteInfo = ZERO_CHECK;
-		};
-		EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 0849225D50C7465FA3475BAB;
-			remoteInfo = iccFromXml;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		A27CC4AEECD7422AB7C96F37 /* iccFromXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccFromXml; sourceTree = BUILT_PRODUCTS_DIR; };
-		A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
-		C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-/* End PBXFileReference section */
+		8DD106136FF3498BBD0A0B66 /* IccToXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = IccToXml; sourceTree = BUILT_PRODUCTS_DIR; };
+		D110157AAC074692BD1CDFD0 /* IccToXml.cpp */ = {isa = PBXBuildFile; fileRef = 9F1A73B9F559435CB88C27C3 /* IccToXml.cpp */; };
+		ED383BBDA629417585AAF958 /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = AB185A867DDD4D88A63F2DE8 /* CMakeLists.txt */; };
+/* End PBXBuildFile section */
+
 
 /* Begin PBXFrameworksBuildPhase section */
-		72494E5A03644528AD44602E /* Frameworks */ = {
+		7EDB4E6DF2F044ABA2515F2D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -110,68 +111,68 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2802CDAFC8C04419AA6B39B4 /* Resources */ = {
+		00505E7E6F544B6585F873A8 /* IccToXml */ = {
+			isa = PBXGroup;
+			children = (
+				7DCE9B34935F45F1BB121DCA /* Source Files */,
+				AB185A867DDD4D88A63F2DE8 /* CMakeLists.txt */,
+			);
+			name = IccToXml;
+			sourceTree = "<group>";
+		};
+		1A6B7AC4BC8642E489F658BF /* Resources */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		355600AF39424A1EBBE1F18E /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				A27CC4AEECD7422AB7C96F37 /* iccFromXml */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		3C7151C6DE4440EC87CC158F /* Source Files */ = {
-			isa = PBXGroup;
-			children = (
-				A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */,
-			);
-			name = "Source Files";
-			sourceTree = "<group>";
-		};
-		3FC12FCAF8FB439D9EC19F19 /* Frameworks */ = {
+		209B552DB5BE4232B05F08C9 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		43EC4EBC399C42D79CFEFDB4 /* iccFromXml */ = {
+		7DCE9B34935F45F1BB121DCA /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
-				3C7151C6DE4440EC87CC158F /* Source Files */,
-				C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */,
+				9F1A73B9F559435CB88C27C3 /* IccToXml.cpp */,
 			);
-			name = iccFromXml;
+			name = "Source Files";
 			sourceTree = "<group>";
 		};
-		8F94EBF8105949008CA203D2 = {
+		960F7A7F366449A09B491056 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				43EC4EBC399C42D79CFEFDB4 /* iccFromXml */,
-				F96B2AB09EC841B7B3EB073E /* ALL_BUILD */,
-				355600AF39424A1EBBE1F18E /* Products */,
-				3FC12FCAF8FB439D9EC19F19 /* Frameworks */,
-				2802CDAFC8C04419AA6B39B4 /* Resources */,
+				8DD106136FF3498BBD0A0B66 /* IccToXml */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B940914224264DEA8ABE3745 = {
+			isa = PBXGroup;
+			children = (
+				00505E7E6F544B6585F873A8 /* IccToXml */,
+				FFB751D45F874E6899E681FE /* ALL_BUILD */,
+				960F7A7F366449A09B491056 /* Products */,
+				209B552DB5BE4232B05F08C9 /* Frameworks */,
+				1A6B7AC4BC8642E489F658BF /* Resources */,
 			);
 			sourceTree = "<group>";
 		};
-		A5958533200D469E91CDE119 /* CMake Rules */ = {
+		F3675B947E1F4F988F1A39C1 /* CMake Rules */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = "CMake Rules";
 			sourceTree = "<group>";
 		};
-		F96B2AB09EC841B7B3EB073E /* ALL_BUILD */ = {
+		FFB751D45F874E6899E681FE /* ALL_BUILD */ = {
 			isa = PBXGroup;
 			children = (
-				A5958533200D469E91CDE119 /* CMake Rules */,
-				CAA076C4D5824AC39CFB7463 /* CMakeLists.txt */,
+				F3675B947E1F4F988F1A39C1 /* CMake Rules */,
+				C61D0FC2614141739D605622 /* CMakeLists.txt */,
 			);
 			name = ALL_BUILD;
 			sourceTree = "<group>";
@@ -179,56 +180,56 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		0849225D50C7465FA3475BAB /* iccFromXml */ = {
+		3D15BBDF81A64CBB95C23721 /* IccToXml */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */;
+			buildConfigurationList = F4583BCB5CF64FFBA9BEF517 /* Build configuration list for PBXNativeTarget "IccToXml" */;
 			buildPhases = (
-				21DEDFAA4F1046CB95DC78A3 /* Sources */,
-				72494E5A03644528AD44602E /* Frameworks */,
+				D8A1EEE8C6BB49FEBC4C35A1 /* Sources */,
+				7EDB4E6DF2F044ABA2515F2D /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */,
+				7EC27BD6D8C645EFBB93357E /* PBXTargetDependency */,
 			);
-			name = iccFromXml;
-			productName = iccFromXml;
-			productReference = A27CC4AEECD7422AB7C96F37 /* iccFromXml */;
+			name = IccToXml;
+			productName = IccToXml;
+			productReference = 8DD106136FF3498BBD0A0B66 /* IccToXml */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		971E2AB583DA413F945C8805 /* Project object */ = {
+		6A45B90AD63543428DA3A3AA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1540;
 			};
-			buildConfigurationList = 2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */;
+			buildConfigurationList = AF6BD83330EB4367A43C0EC1 /* Build configuration list for PBXProject "IccToXml" */;
 			buildSettings = {
 			};
 			buildStyles = (
-				9AEDED2F2422459ABDC7E33F /* Debug */,
-				4E651F165EDD4BEC9AC17500 /* Release */,
-				F106AE83021243D2947F61BB /* MinSizeRel */,
-				FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */,
+				A3F5B1BE70574220A7803536 /* Debug */,
+				679CA637460D4BB684E4F565 /* Release */,
+				10E4CEFBD6204CF5A7100CD3 /* MinSizeRel */,
+				72EC00AE80F6485083B6908A /* RelWithDebInfo */,
 			);
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 0;
-			mainGroup = 8F94EBF8105949008CA203D2;
+			mainGroup = B940914224264DEA8ABE3745;
 			projectDirPath = .;
 			projectRoot = "";
 			targets = (
-				1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */,
-				3411FAD0C406493487491837 /* ZERO_CHECK */,
-				0849225D50C7465FA3475BAB /* iccFromXml */,
+				A870E0F59168450AB7955BFD /* ALL_BUILD */,
+				3D15BBDF81A64CBB95C23721 /* IccToXml */,
+				6156AFFF05EF4745A09FB15D /* ZERO_CHECK */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */ = {
+		14A5F83B6D29791B56CE0898 /* Generate CMakeFiles/ALL_BUILD */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -238,31 +239,31 @@
 			);
 			name = "Generate CMakeFiles/ALL_BUILD";
 			outputPaths = (
-"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
+				"$(SRCROOT)/IccXML/CmdLine/IccToXml/CMakeFiles/ALL_BUILD"
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-SRCROOT=$(pwd)
-if [ \"$CONFIGURATION\" = \"Debug\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Debug\"; then :
+  cd \"$SRCROOT/IccXML/CmdLine/IccToXml\"
+  echo Build\\ all\\ projects
 fi
-if [ \"$CONFIGURATION\" = \"Release\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Release\"; then :
+  cd \"$SRCROOT/IccXML/CmdLine/IccToXml\"
+  echo Build\\ all\\ projects
 fi
-if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
+  cd \"$SRCROOT/IccXML/CmdLine/IccToXml\"
+  echo Build\\ all\\ projects
 fi
-if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
+  cd \"$SRCROOT/IccXML/CmdLine/IccToXml\"
+  echo Build\\ all\\ projects
 fi
 ";
 			showEnvVarsInLog = 0;
 		};
+/* End PBXShellScriptBuildPhase section */
 		3C0110FC8322DE7E50886E21 = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -278,8 +279,7 @@ fi
 exit 0";
 			showEnvVarsInLog = 0;
 		};
-/* Begin PBXShellScriptBuildPhase section */
-		250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */ = {
+		4EE8C1BE3C86D4BB0CC13A0A /* Generate CMakeFiles/ZERO_CHECK */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -287,29 +287,27 @@ exit 0";
 			);
 			inputPaths = (
 			);
-			name = "Generate CMakeFiles/ALL_BUILD";
+			name = "Generate CMakeFiles/ZERO_CHECK";
 			outputPaths = (
-"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
-			);
+"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeFiles/ZERO_CHECK"			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-SRCROOT=$(pwd)
-if [ \"$CONFIGURATION\" = \"Debug\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Debug\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeScripts/ReRunCMake.make
 fi
-if [ \"$CONFIGURATION\" = \"Release\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"Release\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeScripts/ReRunCMake.make
 fi
-if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeScripts/ReRunCMake.make
 fi
-if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
-  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
-  echo Build all projects
+if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
+  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml
+  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeScripts/ReRunCMake.make
 fi
 ";
 			showEnvVarsInLog = 0;
@@ -332,173 +330,93 @@ exit 0";
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		21DEDFAA4F1046CB95DC78A3 /* Sources */ = {
+		D8A1EEE8C6BB49FEBC4C35A1 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-60493C99C20A488A9645C356 /* ../IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
+				D110157AAC074692BD1CDFD0 /* IccToXml.cpp */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */ = {
+		7EC27BD6D8C645EFBB93357E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
-			targetProxy = 817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */;
+			target = 6156AFFF05EF4745A09FB15D /* ZERO_CHECK */;
+			targetProxy = AD1FA1E5353C487AA4706CEB /* PBXContainerItemProxy */;
 		};
-		8B7DFF8C11374DDA87445254 /* PBXTargetDependency */ = {
+		AC667993240C4CDF9AE55BCA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 0849225D50C7465FA3475BAB /* iccFromXml */;
-			targetProxy = EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */;
+			target = 6156AFFF05EF4745A09FB15D /* ZERO_CHECK */;
+			targetProxy = 8C5113A127D94DD3A90DD525 /* PBXContainerItemProxy */;
 		};
-		F5480FD0B0A84C77934A9037 /* PBXTargetDependency */ = {
+		F8BBBEE7EA58456196421F8B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
-			targetProxy = D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */;
+			target = 3D15BBDF81A64CBB95C23721 /* IccToXml */;
+			targetProxy = 319818F2D82D4EBE856BD28A /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		006A88015E504B0E83FD58DE /* RelWithDebInfo */ = {
+		064BCFD59DD345CFAA64F0E9 /* MinSizeRel */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/RelWithDebInfo";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 2;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../..","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
-				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccFromXml;
-				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		0905BB31542547E1BD5EA790 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		15BBFE118EE545D5A94D2295 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		24AF7FAFD05F43FA87387EB3 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Release;
-		};
-		2D7E84543EB34209BA26C2A4 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccToXml/build";
 			};
 			name = MinSizeRel;
 		};
-		3AFA782460FF42EBAD7FDE09 /* Release */ = {
+		0CEC6869B45C46F7A040BBBD /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ARCHS = x86_64;
 				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
 				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccToXml/build";
 			};
 			name = Release;
 		};
-		49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
-			};
-			name = RelWithDebInfo;
-		};
-/* Begin XCBuildConfiguration section */
-		50EA0E9AD6554940822C6F5D /* Debug */ = {
+		2571D8313969435393B4AFA1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Debug";
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Release";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = IccToXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/build/IccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+/* Begin XCBuildConfiguration section */
+		287CDA8DF1D146BA82A11289 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccToXml/Debug";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -514,9 +432,8 @@ exit 0";
 				);
 				INSTALL_PATH = "";
 				LD_RUNPATH_SEARCH_PATHS = (
-					"$(PROJECT_DIR)/../../../IccProfLib",
-					"$(PROJECT_DIR)/../..",
-					"$(PROJECT_DIR)/../../IccLibXML",
+					"$(PROJECT_DIR)/../../../Build/IccProfLib",
+					"$(PROJECT_DIR)/../../../Build/IccXML",
 					"$(inherited)"
 				);
 				LIBRARY_SEARCH_PATHS = (
@@ -535,46 +452,25 @@ exit 0";
 					"$(inherited)"
 				);
 				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccFromXml;
+				PRODUCT_NAME = IccToXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccToXml/build/IccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = Debug;
 		};
 /* End XCBuildConfiguration section */
-83073211A6EE44CFB2DA3A3F /* MinSizeRel */ = {
-	isa = XCBuildConfiguration;
-	buildSettings = {
-		ALWAYS_SEARCH_USER_PATHS = NO;
-		ARCHS = x86_64;
-		COMBINE_HIDPI_IMAGES = YES;
-		CONFIGURATION_BUILD_DIR = "MinSizeRel";
-		EXECUTABLE_PREFIX = "";
-		EXECUTABLE_SUFFIX = "";
-		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-		GCC_OPTIMIZATION_LEVEL = s;
-		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-		HEADER_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../IccProfLib", "$(PROJECT_DIR)/../..", "$(PROJECT_DIR)/../../IccLibXML", "$(inherited)");
-		INSTALL_PATH = "";
-		LD_RUNPATH_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
-		LIBRARY_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
-		ONLY_ACTIVE_ARCH = NO;
-		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-		OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
-		OTHER_REZFLAGS = "";
-		PRODUCT_NAME = iccFromXml;
-		SECTORDER_FLAGS = "";
-		TARGET_TEMP_DIR = "$(PROJECT_DIR)/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-		USE_HEADERMAP = NO;
-		WARNING_CFLAGS = ("$(inherited)");
-	};
-	name = MinSizeRel;
-};
-		6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */ = {
+		377BF529DCF849DAADE73334 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccToXml/build";
+			};
+			name = Debug;
+		};
+		3D65B9DB22A547B4BF548A3F /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -592,18 +488,9 @@ exit 0";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
-			name = MinSizeRel;
-		};
-		75805ECF690B472E804707F7 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SYMROOT = "$(PROJECT_DIR)/build";
-			};
 			name = Debug;
 		};
-		794243A7B31541E08DC890FB /* Release */ = {
+		4A70F91B7D2646BCA0C624F4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -623,7 +510,177 @@ exit 0";
 			};
 			name = Release;
 		};
-		C5AB712B1F4847769A717E3F /* Debug */ = {
+		4E3EA8EF2D9547C3BAE58830 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		5414E7C9F7E84DD9A5065116 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		61D441FEB9CF49BEB2EA066F /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		7D4F7C61A81845F281D78123 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+		82FA749FECA7405DA55B3FE5 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccToXml/build";
+			};
+			name = RelWithDebInfo;
+		};
+		B4CC4BA1589F4B41907D2CE3 /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/RelWithDebInfo";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 2;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = IccToXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/build/IccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		B999251FDEA74EADA166489E /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = RelWithDebInfo;
+		};
+		C726A33EC84544E08BD510C6 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/MinSizeRel";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = s;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = IccToXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/build/IccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		FBFA6743D30D43A6AACDAE69 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -643,134 +700,54 @@ exit 0";
 			};
 			name = Debug;
 		};
-		DB4D0FBC109F4DCF8958010E /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "$(PROJECT_DIR)/build";
-			};
-			name = MinSizeRel;
-		};
-		E4BCD06E442943BDBA6E5671 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-E9B85C98251F448AA762F198 /* Release */ = {
-	isa = XCBuildConfiguration;
-	buildSettings = {
-		ALWAYS_SEARCH_USER_PATHS = NO;
-		ARCHS = x86_64;
-		COMBINE_HIDPI_IMAGES = YES;
-		CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Release";
-		EXECUTABLE_PREFIX = "";
-		EXECUTABLE_SUFFIX = "";
-		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-		GCC_OPTIMIZATION_LEVEL = 3;
-		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-		HEADER_SEARCH_PATHS = (
-			"$(PROJECT_DIR)/../../../IccProfLib",
-			"$(PROJECT_DIR)/../..",
-			"$(PROJECT_DIR)/../../IccLibXML",
-			"$(inherited)"
-		);
-		INSTALL_PATH = "";
-		LD_RUNPATH_SEARCH_PATHS = (
-			"$(PROJECT_DIR)/../../../Build/IccProfLib",
-			"$(PROJECT_DIR)/../../../Build/IccXML",
-			"$(inherited)"
-		);
-		LIBRARY_SEARCH_PATHS = (
-			"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
-			"$(PROJECT_DIR)/../../../Build/IccProfLib",
-			"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
-			"$(PROJECT_DIR)/../../../Build/IccXML",
-			"$(inherited)"
-		);
-		ONLY_ACTIVE_ARCH = NO;
-		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-		OTHER_LDFLAGS = (
-			" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
-			"-lIccProfLib2.2",
-			"-lIccXML2.2",
-			"$(inherited)"
-		);
-		OTHER_REZFLAGS = "";
-		PRODUCT_NAME = iccFromXml;
-		SECTORDER_FLAGS = "";
-		TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-		USE_HEADERMAP = NO;
-		WARNING_CFLAGS = ("$(inherited)");
-	};
-	name = Release;
-};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
+		41E2965D435E4F6595251DF6 /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				E4BCD06E442943BDBA6E5671 /* Debug */,
-				24AF7FAFD05F43FA87387EB3 /* Release */,
-				6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */,
-				0905BB31542547E1BD5EA790 /* RelWithDebInfo */,
+				FBFA6743D30D43A6AACDAE69 /* Debug */,
+				4A70F91B7D2646BCA0C624F4 /* Release */,
+				4E3EA8EF2D9547C3BAE58830 /* MinSizeRel */,
+				5414E7C9F7E84DD9A5065116 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */ = {
+		79B6EE6DE00548F0B7C0D8A1 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				75805ECF690B472E804707F7 /* Debug */,
-				3AFA782460FF42EBAD7FDE09 /* Release */,
-				DB4D0FBC109F4DCF8958010E /* MinSizeRel */,
-				49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */,
+				3D65B9DB22A547B4BF548A3F /* Debug */,
+				7D4F7C61A81845F281D78123 /* Release */,
+				61D441FEB9CF49BEB2EA066F /* MinSizeRel */,
+				B999251FDEA74EADA166489E /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
+		AF6BD83330EB4367A43C0EC1 /* Build configuration list for PBXProject "IccToXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				C5AB712B1F4847769A717E3F /* Debug */,
-				794243A7B31541E08DC890FB /* Release */,
-				2D7E84543EB34209BA26C2A4 /* MinSizeRel */,
-				15BBFE118EE545D5A94D2295 /* RelWithDebInfo */,
+				377BF529DCF849DAADE73334 /* Debug */,
+				0CEC6869B45C46F7A040BBBD /* Release */,
+				064BCFD59DD345CFAA64F0E9 /* MinSizeRel */,
+				82FA749FECA7405DA55B3FE5 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
+		F4583BCB5CF64FFBA9BEF517 /* Build configuration list for PBXNativeTarget "IccToXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				50EA0E9AD6554940822C6F5D /* Debug */,
-				E9B85C98251F448AA762F198 /* Release */,
-				6573C4FE7C584052A79F126E /* MinSizeRel */,
-				006A88015E504B0E83FD58DE /* RelWithDebInfo */,
+				287CDA8DF1D146BA82A11289 /* Debug */,
+				2571D8313969435393B4AFA1 /* Release */,
+				C726A33EC84544E08BD510C6 /* MinSizeRel */,
+				B4CC4BA1589F4B41907D2CE3 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 971E2AB583DA413F945C8805 /* Project object */;
+	rootObject = 6A45B90AD63543428DA3A3AA /* Project object */;
 }

--- a/IccXML/CmdLine/IccToXml/IccToXML.xcodeproj/project.pbxproj
+++ b/IccXML/CmdLine/IccToXml/IccToXML.xcodeproj/project.pbxproj
@@ -7,101 +7,100 @@
 	objects = {
 
 /* Begin PBXAggregateTarget section */
-		575FEB3C626F4A8DA6674D3C /* ZERO_CHECK */ = {
+		1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */ = {
 			isa = PBXAggregateTarget;
-			buildConfigurationList = 049D73B8EA474F70AFBF9D73 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
+			buildConfigurationList = 4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
 			buildPhases = (
-				31841FA1DDC4B0555EB46CC8 /* Generate CMakeFiles/ZERO_CHECK */,
+				250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */,
+			);
+			dependencies = (
+				F5480FD0B0A84C77934A9037 /* PBXTargetDependency */,
+				8B7DFF8C11374DDA87445254 /* PBXTargetDependency */,
+			);
+			name = ALL_BUILD;
+			productName = ALL_BUILD;
+		};
+		3411FAD0C406493487491837 /* ZERO_CHECK */ = {
+			isa = PBXAggregateTarget;
+			buildConfigurationList = 08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */;
+			buildPhases = (
+				5CC6AF3ADA2C925AFFEB6253 /* Generate CMakeFiles/ZERO_CHECK */,
 			);
 			dependencies = (
 			);
 			name = ZERO_CHECK;
 			productName = ZERO_CHECK;
 		};
-		643B419DAC7341D189F9C237 /* ALL_BUILD */ = {
-			isa = PBXAggregateTarget;
-			buildConfigurationList = 88DBA1FE2D66418CBC919C9A /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */;
-			buildPhases = (
-				9EBF23F8361934FE22864E63 /* Generate CMakeFiles/ALL_BUILD */,
-			);
-			dependencies = (
-				AEB36F37986F4C4E9CD103C9 /* PBXTargetDependency */,
-				0C387A0BA4C44D0A893B8B0B /* PBXTargetDependency */,
-			);
-			name = ALL_BUILD;
-			productName = ALL_BUILD;
-		};
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		87D51264B15341A681546161 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/iccToXml.cpp */ = {isa = PBXBuildFile; fileRef = 0734C97DF3254B399089EC68 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/iccToXml.cpp */; };
-		AD20BA05667643FA96DA0A9E /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = 2BE13D13FA464DBA94A86887 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeLists.txt */; };
+	60493C99C20A488A9645C356 /* IccFromXml.cpp */ = {isa = PBXBuildFile; fileRef = A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */; };
+	713F6E42ABF94FEBAA9DA4CC /* CMakeLists.txt */ = {isa = PBXBuildFile; fileRef = C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildStyle section */
-		03E73035D6364CDF826477B6 /* RelWithDebInfo */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = RelWithDebInfo;
-		};
-		0CDD98959D274802B47E91BA /* Debug */ = {
-			isa = PBXBuildStyle;
-			buildSettings = {
-				COPY_PHASE_STRIP = NO;
-			};
-			name = Debug;
-		};
-		53F78DADAFCB45508715A27D /* Release */ = {
+		4E651F165EDD4BEC9AC17500 /* Release */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = Release;
 		};
-		9B6A015DE9E448EDAF94EA12 /* MinSizeRel */ = {
+		9AEDED2F2422459ABDC7E33F /* Debug */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = Debug;
+		};
+		F106AE83021243D2947F61BB /* MinSizeRel */ = {
 			isa = PBXBuildStyle;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
 			};
 			name = MinSizeRel;
 		};
+		FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */ = {
+			isa = PBXBuildStyle;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+			};
+			name = RelWithDebInfo;
+		};
 /* End PBXBuildStyle section */
 
 /* Begin PBXContainerItemProxy section */
-		58FD9237A9EE416DB333AF09 /* PBXContainerItemProxy */ = {
+		817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 87ACAFCAB2F24B8886321A21 /* Project object */;
+			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 575FEB3C626F4A8DA6674D3C;
+			remoteGlobalIDString = 3411FAD0C406493487491837;
 			remoteInfo = ZERO_CHECK;
 		};
-		5E9061AC5B734E329411CAB1 /* PBXContainerItemProxy */ = {
+		D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = 87ACAFCAB2F24B8886321A21 /* Project object */;
+			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = 4CC0EC8137374DF48447B083;
-			remoteInfo = iccToXml;
-		};
-		DCC5ED75855E40608F910303 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 87ACAFCAB2F24B8886321A21 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 575FEB3C626F4A8DA6674D3C;
+			remoteGlobalIDString = 3411FAD0C406493487491837;
 			remoteInfo = ZERO_CHECK;
+		};
+		EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 971E2AB583DA413F945C8805 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 0849225D50C7465FA3475BAB;
+			remoteInfo = iccFromXml;
 		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0734C97DF3254B399089EC68 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/iccToXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = iccToXml.cpp; path = iccToXml.cpp; sourceTree = SOURCE_ROOT; };
-		2BE13D13FA464DBA94A86887 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		B496DD9965C54BD58A75E78E /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
-		B8EE9C13C8584EDA8D83C3AD /* iccToXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccToXml; sourceTree = BUILT_PRODUCTS_DIR; };
+		A27CC4AEECD7422AB7C96F37 /* iccFromXml */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = iccFromXml; sourceTree = BUILT_PRODUCTS_DIR; };
+		A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.cpp; fileEncoding = 4; name = IccFromXml.cpp; path = IccFromXml.cpp; sourceTree = SOURCE_ROOT; };
+		C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */ = {isa = PBXFileReference; explicitFileType = sourcecode.text; fileEncoding = 4; name = CMakeLists.txt; path = CMakeLists.txt; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		67FFAE2D10BD4807AFB0082D /* Frameworks */ = {
+		72494E5A03644528AD44602E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -111,125 +110,125 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		2018FEAA49E64A97BC7ED47E /* Frameworks */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		3FB0662A4EB4426FA4E48642 /* Resources */ = {
+		2802CDAFC8C04419AA6B39B4 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = Resources;
 			sourceTree = "<group>";
 		};
-		41A662C2B6B5417D91EE675A /* iccToXml */ = {
+		355600AF39424A1EBBE1F18E /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				6EE9F7BF80BF4094948B8FFC /* Source Files */,
-				2BE13D13FA464DBA94A86887 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeLists.txt */,
-			);
-			name = iccToXml;
-			sourceTree = "<group>";
-		};
-		423A81CB45F24BC0B5D4F688 /* ALL_BUILD */ = {
-			isa = PBXGroup;
-			children = (
-				DED9AEBB53B4478ABAF6BB10 /* CMake Rules */,
-				B496DD9965C54BD58A75E78E /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/CMakeLists.txt */,
-			);
-			name = ALL_BUILD;
-			sourceTree = "<group>";
-		};
-		4670DBC3A42B4EF0B23D5175 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				B8EE9C13C8584EDA8D83C3AD /* iccToXml */,
+				A27CC4AEECD7422AB7C96F37 /* iccFromXml */,
 			);
 			name = Products;
 			sourceTree = "<group>";
 		};
-		6EE9F7BF80BF4094948B8FFC /* Source Files */ = {
+		3C7151C6DE4440EC87CC158F /* Source Files */ = {
 			isa = PBXGroup;
 			children = (
-				0734C97DF3254B399089EC68 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/iccToXml.cpp */,
+				A5A20E83F4C74D06BB9DB3B7 /* IccFromXml.cpp */,
 			);
 			name = "Source Files";
 			sourceTree = "<group>";
 		};
-		8E38E399E8544B84A5425354 = {
+		3FC12FCAF8FB439D9EC19F19 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				41A662C2B6B5417D91EE675A /* iccToXml */,
-				423A81CB45F24BC0B5D4F688 /* ALL_BUILD */,
-				4670DBC3A42B4EF0B23D5175 /* Products */,
-				2018FEAA49E64A97BC7ED47E /* Frameworks */,
-				3FB0662A4EB4426FA4E48642 /* Resources */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		43EC4EBC399C42D79CFEFDB4 /* iccFromXml */ = {
+			isa = PBXGroup;
+			children = (
+				3C7151C6DE4440EC87CC158F /* Source Files */,
+				C9FDB50EE9D54E689E8A51BF /* CMakeLists.txt */,
+			);
+			name = iccFromXml;
+			sourceTree = "<group>";
+		};
+		8F94EBF8105949008CA203D2 = {
+			isa = PBXGroup;
+			children = (
+				43EC4EBC399C42D79CFEFDB4 /* iccFromXml */,
+				F96B2AB09EC841B7B3EB073E /* ALL_BUILD */,
+				355600AF39424A1EBBE1F18E /* Products */,
+				3FC12FCAF8FB439D9EC19F19 /* Frameworks */,
+				2802CDAFC8C04419AA6B39B4 /* Resources */,
 			);
 			sourceTree = "<group>";
 		};
-		DED9AEBB53B4478ABAF6BB10 /* CMake Rules */ = {
+		A5958533200D469E91CDE119 /* CMake Rules */ = {
 			isa = PBXGroup;
 			children = (
 			);
 			name = "CMake Rules";
 			sourceTree = "<group>";
 		};
+		F96B2AB09EC841B7B3EB073E /* ALL_BUILD */ = {
+			isa = PBXGroup;
+			children = (
+				A5958533200D469E91CDE119 /* CMake Rules */,
+				CAA076C4D5824AC39CFB7463 /* CMakeLists.txt */,
+			);
+			name = ALL_BUILD;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
-		4CC0EC8137374DF48447B083 /* iccToXml */ = {
+		0849225D50C7465FA3475BAB /* iccFromXml */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 77F57DFD36914609A565F530 /* Build configuration list for PBXNativeTarget "iccToXml" */;
+			buildConfigurationList = C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */;
 			buildPhases = (
-				7D7A39EE18A64CD2A3722B6C /* Sources */,
-				67FFAE2D10BD4807AFB0082D /* Frameworks */,
+				21DEDFAA4F1046CB95DC78A3 /* Sources */,
+				72494E5A03644528AD44602E /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				8A3A1A998C1749DC8CB6B2F5 /* PBXTargetDependency */,
+				3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */,
 			);
-			name = iccToXml;
-			productName = iccToXml;
-			productReference = B8EE9C13C8584EDA8D83C3AD /* iccToXml */;
+			name = iccFromXml;
+			productName = iccFromXml;
+			productReference = A27CC4AEECD7422AB7C96F37 /* iccFromXml */;
 			productType = "com.apple.product-type.tool";
 		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
-		87ACAFCAB2F24B8886321A21 /* Project object */ = {
+		971E2AB583DA413F945C8805 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 1540;
 			};
-			buildConfigurationList = 6299334E4C944F879567B228 /* Build configuration list for PBXProject "IccToXml" */;
+			buildConfigurationList = 2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */;
 			buildSettings = {
 			};
 			buildStyles = (
-				0CDD98959D274802B47E91BA /* Debug */,
-				53F78DADAFCB45508715A27D /* Release */,
-				9B6A015DE9E448EDAF94EA12 /* MinSizeRel */,
-				03E73035D6364CDF826477B6 /* RelWithDebInfo */,
+				9AEDED2F2422459ABDC7E33F /* Debug */,
+				4E651F165EDD4BEC9AC17500 /* Release */,
+				F106AE83021243D2947F61BB /* MinSizeRel */,
+				FF0A7EF403A242D9AC607A0A /* RelWithDebInfo */,
 			);
 			compatibilityVersion = "Xcode 3.2";
 			hasScannedForEncodings = 0;
-			mainGroup = 8E38E399E8544B84A5425354;
-			projectDirPath = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml";
+			mainGroup = 8F94EBF8105949008CA203D2;
+			projectDirPath = .;
 			projectRoot = "";
 			targets = (
-				643B419DAC7341D189F9C237 /* ALL_BUILD */,
-				575FEB3C626F4A8DA6674D3C /* ZERO_CHECK */,
-				4CC0EC8137374DF48447B083 /* iccToXml */,
+				1A55A1DD914D4AED9FB40A86 /* ALL_BUILD */,
+				3411FAD0C406493487491837 /* ZERO_CHECK */,
+				0849225D50C7465FA3475BAB /* iccFromXml */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		31841FA1DDC4B0555EB46CC8 /* Generate CMakeFiles/ZERO_CHECK */ = {
+		250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
@@ -237,27 +236,29 @@
 			);
 			inputPaths = (
 			);
-			name = "Generate CMakeFiles/ZERO_CHECK";
+			name = "Generate CMakeFiles/ALL_BUILD";
 			outputPaths = (
-"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/CMakeFiles/ZERO_CHECK"			);
+"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
+			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "set -e
-if test \"$CONFIGURATION\" = \"Debug\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/CMakeScripts/ReRunCMake.make
+SRCROOT=$(pwd)
+if [ \"$CONFIGURATION\" = \"Debug\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"Release\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/CMakeScripts/ReRunCMake.make
+if [ \"$CONFIGURATION\" = \"Release\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/CMakeScripts/ReRunCMake.make
+if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
-if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  make -f /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/CMakeScripts/ReRunCMake.make
+if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
 fi
 ";
 			showEnvVarsInLog = 0;
@@ -277,6 +278,42 @@ fi
 exit 0";
 			showEnvVarsInLog = 0;
 		};
+/* Begin PBXShellScriptBuildPhase section */
+		250CBE123758CA9590BC499A /* Generate CMakeFiles/ALL_BUILD */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Generate CMakeFiles/ALL_BUILD";
+			outputPaths = (
+"$(SRCROOT)/IccXML/CmdLine/IccFromXml/CMakeFiles/ALL_BUILD"
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "set -e
+SRCROOT=$(pwd)
+if [ \"$CONFIGURATION\" = \"Debug\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
+fi
+if [ \"$CONFIGURATION\" = \"Release\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
+fi
+if [ \"$CONFIGURATION\" = \"MinSizeRel\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
+fi
+if [ \"$CONFIGURATION\" = \"RelWithDebInfo\" ]; then
+  cd \"${SRCROOT}/IccXML/CmdLine/IccFromXml\"
+  echo Build all projects
+fi
+";
+			showEnvVarsInLog = 0;
+		};
 		9B50530E35CC49C82C2FACCF = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -292,198 +329,45 @@ exit 0";
 exit 0";
 			showEnvVarsInLog = 0;
 		};
-		9EBF23F8361934FE22864E63 /* Generate CMakeFiles/ALL_BUILD */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = "Generate CMakeFiles/ALL_BUILD";
-			outputPaths = (
-"/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/CMakeFiles/ALL_BUILD"			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "set -e
-if test \"$CONFIGURATION\" = \"Debug\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  echo Build\\ all\\ projects
-fi
-if test \"$CONFIGURATION\" = \"Release\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  echo Build\\ all\\ projects
-fi
-if test \"$CONFIGURATION\" = \"MinSizeRel\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  echo Build\\ all\\ projects
-fi
-if test \"$CONFIGURATION\" = \"RelWithDebInfo\"; then :
-  cd /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build
-  echo Build\\ all\\ projects
-fi
-";
-			showEnvVarsInLog = 0;
-		};
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		7D7A39EE18A64CD2A3722B6C /* Sources */ = {
+		21DEDFAA4F1046CB95DC78A3 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				87D51264B15341A681546161 /* /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/iccToXml.cpp */,
+60493C99C20A488A9645C356 /* ../IccXML/CmdLine/IccFromXml/IccFromXml.cpp */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		0C387A0BA4C44D0A893B8B0B /* PBXTargetDependency */ = {
+		3D609FE3203A43EBB3EF0617 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 4CC0EC8137374DF48447B083 /* iccToXml */;
-			targetProxy = 5E9061AC5B734E329411CAB1 /* PBXContainerItemProxy */;
+			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
+			targetProxy = 817CBE26E6D7417195CF8DED /* PBXContainerItemProxy */;
 		};
-		8A3A1A998C1749DC8CB6B2F5 /* PBXTargetDependency */ = {
+		8B7DFF8C11374DDA87445254 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 575FEB3C626F4A8DA6674D3C /* ZERO_CHECK */;
-			targetProxy = DCC5ED75855E40608F910303 /* PBXContainerItemProxy */;
+			target = 0849225D50C7465FA3475BAB /* iccFromXml */;
+			targetProxy = EECA5200DD6F489494A5FE18 /* PBXContainerItemProxy */;
 		};
-		AEB36F37986F4C4E9CD103C9 /* PBXTargetDependency */ = {
+		F5480FD0B0A84C77934A9037 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 575FEB3C626F4A8DA6674D3C /* ZERO_CHECK */;
-			targetProxy = 58FD9237A9EE416DB333AF09 /* PBXContainerItemProxy */;
+			target = 3411FAD0C406493487491837 /* ZERO_CHECK */;
+			targetProxy = D2788DC6B8A547C7A87C10F2 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
-		055DEA3E11FD4189A5C9B357 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = RelWithDebInfo;
-		};
-		122ADD4DEC7F4B418EDD9B43 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-		1D0755AFA9E24E0999F5A8AD /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ALL_BUILD;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Release;
-		};
-		2EC11E7ECE0745318C536E16 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = MinSizeRel;
-		};
-		3CF4888DB71349D8BAB6E930 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build";
-			};
-			name = Release;
-		};
-		542FB26DF47F4E549C767236 /* Debug */ = {
+		006A88015E504B0E83FD58DE /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/Debug";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
-				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "   ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2","-lIccXML2","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccToXml;
-				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build/iccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-		63FD0B6924E84CBC9C4C3D14 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/RelWithDebInfo";
+				CONFIGURATION_BUILD_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/RelWithDebInfo";
 				EXECUTABLE_PREFIX = "";
 				EXECUTABLE_SUFFIX = "";
 				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
@@ -491,23 +375,23 @@ fi
 				GCC_OPTIMIZATION_LEVEL = 2;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
+				HEADER_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../..","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
+				LD_RUNPATH_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
+				LIBRARY_SEARCH_PATHS = ("$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccProfLib","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","$(SRCROOT)/IccXML/CmdLine/IccFromXml/../../../Build/IccXML","$(inherited)");
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_CPLUSPLUSFLAGS = "       -DNDEBUG ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2","-lIccXML2","$(inherited)");
+				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
 				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccToXml;
+				PRODUCT_NAME = iccFromXml;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build/iccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				TARGET_TEMP_DIR = "$(SRCROOT)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
 			name = RelWithDebInfo;
 		};
-		73A5BB24EC594FCDABDC64E9 /* RelWithDebInfo */ = {
+		0905BB31542547E1BD5EA790 /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -527,47 +411,27 @@ fi
 			};
 			name = RelWithDebInfo;
 		};
-		975E4C547D464A0985A2D979 /* Release */ = {
+		15BBFE118EE545D5A94D2295 /* RelWithDebInfo */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
 				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/Release";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
 				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 3;
+				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
 				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2","-lIccXML2","$(inherited)");
+				OTHER_LDFLAGS = ("","$(inherited)");
 				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccToXml;
+				PRODUCT_NAME = ALL_BUILD;
 				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build/iccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				USE_HEADERMAP = NO;
 				WARNING_CFLAGS = ("$(inherited)");
 			};
-			name = Release;
+			name = RelWithDebInfo;
 		};
-		9A3AFB3A534349A0B825C417 /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build";
-			};
-			name = MinSizeRel;
-		};
-		9F8F9E6566C24D2BAF53CB57 /* Release */ = {
+		24AF7FAFD05F43FA87387EB3 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -587,76 +451,7 @@ fi
 			};
 			name = Release;
 		};
-		A63E7DC2639348F186CEE905 /* RelWithDebInfo */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk;
-				SWIFT_COMPILATION_MODE = wholemodule;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build";
-			};
-			name = RelWithDebInfo;
-		};
-		AE140EC395914702AE2EE627 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				COMBINE_HIDPI_IMAGES = YES;
-				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = 0;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				INSTALL_PATH = "";
-				OTHER_LDFLAGS = ("","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = ZERO_CHECK;
-				SECTORDER_FLAGS = "";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = Debug;
-		};
-		AF38224674C04A1AA97FABAD /* MinSizeRel */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = x86_64;
-				COMBINE_HIDPI_IMAGES = YES;
-				CONFIGURATION_BUILD_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/MinSizeRel";
-				EXECUTABLE_PREFIX = "";
-				EXECUTABLE_SUFFIX = "";
-				GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
-				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
-				GCC_OPTIMIZATION_LEVEL = s;
-				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
-				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				HEADER_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../..","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../IccLibXML","$(inherited)");
-				INSTALL_PATH = "";
-				LD_RUNPATH_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib /Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				LIBRARY_SEARCH_PATHS = ("/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccProfLib","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)","/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/../../../Build/IccXML","$(inherited)");
-				ONLY_ACTIVE_ARCH = NO;
-				OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
-				OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2","-lIccXML2","$(inherited)");
-				OTHER_REZFLAGS = "";
-				PRODUCT_NAME = iccToXml;
-				SECTORDER_FLAGS = "";
-				TARGET_TEMP_DIR = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build/iccToXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
-				USE_HEADERMAP = NO;
-				WARNING_CFLAGS = ("$(inherited)");
-			};
-			name = MinSizeRel;
-		};
-		B16C8FE14FB848AA9195C53B /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ARCHS = x86_64;
-				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk;
-				SYMROOT = "/Users/xss/dmax/DemoIccMAX-master/IccXML/CmdLine/IccToXml/Build/build";
-			};
-			name = Debug;
-		};
-		DF05E49450FB46D6B0667BA3 /* MinSizeRel */ = {
+		2D7E84543EB34209BA26C2A4 /* MinSizeRel */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -676,54 +471,306 @@ fi
 			};
 			name = MinSizeRel;
 		};
+		3AFA782460FF42EBAD7FDE09 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = Release;
+		};
+		49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build";
+			};
+			name = RelWithDebInfo;
+		};
+/* Begin XCBuildConfiguration section */
+		50EA0E9AD6554940822C6F5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = x86_64;
+				COMBINE_HIDPI_IMAGES = YES;
+				CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Debug";
+				EXECUTABLE_PREFIX = "";
+				EXECUTABLE_SUFFIX = "";
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../IccProfLib",
+					"$(PROJECT_DIR)/../..",
+					"$(PROJECT_DIR)/../../IccLibXML",
+					"$(inherited)"
+				);
+				INSTALL_PATH = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../IccProfLib",
+					"$(PROJECT_DIR)/../..",
+					"$(PROJECT_DIR)/../../IccLibXML",
+					"$(inherited)"
+				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+					"$(PROJECT_DIR)/../../../Build/IccProfLib",
+					"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+					"$(PROJECT_DIR)/../../../Build/IccXML",
+					"$(inherited)"
+				);
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_CPLUSPLUSFLAGS = "   ";
+				OTHER_LDFLAGS = (
+					" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
+					"-lIccProfLib2.2",
+					"-lIccXML2.2",
+					"$(inherited)"
+				);
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = iccFromXml;
+				SECTORDER_FLAGS = "";
+				TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+/* End XCBuildConfiguration section */
+83073211A6EE44CFB2DA3A3F /* MinSizeRel */ = {
+	isa = XCBuildConfiguration;
+	buildSettings = {
+		ALWAYS_SEARCH_USER_PATHS = NO;
+		ARCHS = x86_64;
+		COMBINE_HIDPI_IMAGES = YES;
+		CONFIGURATION_BUILD_DIR = "MinSizeRel";
+		EXECUTABLE_PREFIX = "";
+		EXECUTABLE_SUFFIX = "";
+		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+		GCC_OPTIMIZATION_LEVEL = s;
+		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+		HEADER_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../IccProfLib", "$(PROJECT_DIR)/../..", "$(PROJECT_DIR)/../../IccLibXML", "$(inherited)");
+		INSTALL_PATH = "";
+		LD_RUNPATH_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
+		LIBRARY_SEARCH_PATHS = ("$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccProfLib", "$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)", "$(PROJECT_DIR)/../../../Build/IccXML", "$(inherited)");
+		ONLY_ACTIVE_ARCH = NO;
+		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+		OTHER_LDFLAGS = (" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names","-lIccProfLib2.2","-lIccXML2.2","$(inherited)");
+		OTHER_REZFLAGS = "";
+		PRODUCT_NAME = iccFromXml;
+		SECTORDER_FLAGS = "";
+		TARGET_TEMP_DIR = "$(PROJECT_DIR)/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+		USE_HEADERMAP = NO;
+		WARNING_CFLAGS = ("$(inherited)");
+	};
+	name = MinSizeRel;
+};
+		6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = MinSizeRel;
+		};
+		75805ECF690B472E804707F7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SYMROOT = "$(PROJECT_DIR)/build";
+			};
+			name = Debug;
+		};
+		794243A7B31541E08DC890FB /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Release;
+		};
+		C5AB712B1F4847769A717E3F /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ALL_BUILD;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+		DB4D0FBC109F4DCF8958010E /* MinSizeRel */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ARCHS = x86_64;
+				SDKROOT = /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SYMROOT = "$(PROJECT_DIR)/build";
+			};
+			name = MinSizeRel;
+		};
+		E4BCD06E442943BDBA6E5671 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_GENERATE_DEBUGGING_SYMBOLS = YES;
+				GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				INSTALL_PATH = "";
+				OTHER_LDFLAGS = ("","$(inherited)");
+				OTHER_REZFLAGS = "";
+				PRODUCT_NAME = ZERO_CHECK;
+				SECTORDER_FLAGS = "";
+				USE_HEADERMAP = NO;
+				WARNING_CFLAGS = ("$(inherited)");
+			};
+			name = Debug;
+		};
+E9B85C98251F448AA762F198 /* Release */ = {
+	isa = XCBuildConfiguration;
+	buildSettings = {
+		ALWAYS_SEARCH_USER_PATHS = NO;
+		ARCHS = x86_64;
+		COMBINE_HIDPI_IMAGES = YES;
+		CONFIGURATION_BUILD_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/Release";
+		EXECUTABLE_PREFIX = "";
+		EXECUTABLE_SUFFIX = "";
+		GCC_GENERATE_DEBUGGING_SYMBOLS = NO;
+		GCC_INLINES_ARE_PRIVATE_EXTERN = NO;
+		GCC_OPTIMIZATION_LEVEL = 3;
+		GCC_PREPROCESSOR_DEFINITIONS = ("'CMAKE_INTDIR=\"$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)\"'","$(inherited)");
+		GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+		HEADER_SEARCH_PATHS = (
+			"$(PROJECT_DIR)/../../../IccProfLib",
+			"$(PROJECT_DIR)/../..",
+			"$(PROJECT_DIR)/../../IccLibXML",
+			"$(inherited)"
+		);
+		INSTALL_PATH = "";
+		LD_RUNPATH_SEARCH_PATHS = (
+			"$(PROJECT_DIR)/../../../Build/IccProfLib",
+			"$(PROJECT_DIR)/../../../Build/IccXML",
+			"$(inherited)"
+		);
+		LIBRARY_SEARCH_PATHS = (
+			"$(PROJECT_DIR)/../../../Build/IccProfLib/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+			"$(PROJECT_DIR)/../../../Build/IccProfLib",
+			"$(PROJECT_DIR)/../../../Build/IccXML/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)",
+			"$(PROJECT_DIR)/../../../Build/IccXML",
+			"$(inherited)"
+		);
+		ONLY_ACTIVE_ARCH = NO;
+		OTHER_CPLUSPLUSFLAGS = "    -DNDEBUG ";
+		OTHER_LDFLAGS = (
+			" -v -Wl,-v -Wl,-search_paths_first -Wl,-headerpad_max_install_names",
+			"-lIccProfLib2.2",
+			"-lIccXML2.2",
+			"$(inherited)"
+		);
+		OTHER_REZFLAGS = "";
+		PRODUCT_NAME = iccFromXml;
+		SECTORDER_FLAGS = "";
+		TARGET_TEMP_DIR = "$(PROJECT_DIR)/IccXML/CmdLine/IccFromXml/build/iccFromXml.build/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
+		USE_HEADERMAP = NO;
+		WARNING_CFLAGS = ("$(inherited)");
+	};
+	name = Release;
+};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
-		049D73B8EA474F70AFBF9D73 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
+		08D31A51151A4759A76AA676 /* Build configuration list for PBXAggregateTarget "ZERO_CHECK" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				AE140EC395914702AE2EE627 /* Debug */,
-				9F8F9E6566C24D2BAF53CB57 /* Release */,
-				2EC11E7ECE0745318C536E16 /* MinSizeRel */,
-				73A5BB24EC594FCDABDC64E9 /* RelWithDebInfo */,
+				E4BCD06E442943BDBA6E5671 /* Debug */,
+				24AF7FAFD05F43FA87387EB3 /* Release */,
+				6FCFA22C8A6D4F458736BAF6 /* MinSizeRel */,
+				0905BB31542547E1BD5EA790 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		6299334E4C944F879567B228 /* Build configuration list for PBXProject "IccToXml" */ = {
+		2A3507C9BF344F9084431682 /* Build configuration list for PBXProject "IccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				B16C8FE14FB848AA9195C53B /* Debug */,
-				3CF4888DB71349D8BAB6E930 /* Release */,
-				9A3AFB3A534349A0B825C417 /* MinSizeRel */,
-				A63E7DC2639348F186CEE905 /* RelWithDebInfo */,
+				75805ECF690B472E804707F7 /* Debug */,
+				3AFA782460FF42EBAD7FDE09 /* Release */,
+				DB4D0FBC109F4DCF8958010E /* MinSizeRel */,
+				49E5E4FEB8574ED5B515EE4D /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		77F57DFD36914609A565F530 /* Build configuration list for PBXNativeTarget "iccToXml" */ = {
+		4DF850511FB845AE82D3900C /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				542FB26DF47F4E549C767236 /* Debug */,
-				975E4C547D464A0985A2D979 /* Release */,
-				AF38224674C04A1AA97FABAD /* MinSizeRel */,
-				63FD0B6924E84CBC9C4C3D14 /* RelWithDebInfo */,
+				C5AB712B1F4847769A717E3F /* Debug */,
+				794243A7B31541E08DC890FB /* Release */,
+				2D7E84543EB34209BA26C2A4 /* MinSizeRel */,
+				15BBFE118EE545D5A94D2295 /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
-		88DBA1FE2D66418CBC919C9A /* Build configuration list for PBXAggregateTarget "ALL_BUILD" */ = {
+		C75C60013ED9483E8EB96EBA /* Build configuration list for PBXNativeTarget "iccFromXml" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				122ADD4DEC7F4B418EDD9B43 /* Debug */,
-				1D0755AFA9E24E0999F5A8AD /* Release */,
-				DF05E49450FB46D6B0667BA3 /* MinSizeRel */,
-				055DEA3E11FD4189A5C9B357 /* RelWithDebInfo */,
+				50EA0E9AD6554940822C6F5D /* Debug */,
+				E9B85C98251F448AA762F198 /* Release */,
+				6573C4FE7C584052A79F126E /* MinSizeRel */,
+				006A88015E504B0E83FD58DE /* RelWithDebInfo */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
 	};
-	rootObject = 87ACAFCAB2F24B8886321A21 /* Project object */;
+	rootObject = 971E2AB583DA413F945C8805 /* Project object */;
 }

--- a/IccXML/CmdLine/IccToXml/xnu_build_cmd_IccToXml.zsh
+++ b/IccXML/CmdLine/IccToXml/xnu_build_cmd_IccToXml.zsh
@@ -1,0 +1,30 @@
+#!/bin/zsh
+
+echo "This Project is configured to manually build a command line tool, you must have already built and installed the dylibs...."
+
+# Project and configurations
+PROJECT="IccToXml.xcodeproj"
+CONFIGURATIONS=("Debug" "Release" "MinSizeRel" "RelWithDebInfo")
+SCHEMES=("ALL_BUILD" "IccToXml" "ZERO_CHECK")
+
+# Destination
+DESTINATION="platform=macOS,arch=x86_64"
+
+# Function to build with a specific configuration and scheme
+build_project() {
+    local scheme=$1
+    local config=$2
+
+    echo "Building scheme '$scheme' with configuration '$config'..."
+    xcodebuild -project "$PROJECT" -scheme "$scheme" -configuration "$config" -destination "$DESTINATION" clean build
+}
+
+# Iterate over configurations and schemes
+for config in "${CONFIGURATIONS[@]}"; do
+    for scheme in "${SCHEMES[@]}"; do
+        build_project "$scheme" "$config"
+    done
+done
+
+echo "All builds completed."
+

--- a/contrib/UnitTest/TestCIccTagXmlProfileSequenceId.cpp
+++ b/contrib/UnitTest/TestCIccTagXmlProfileSequenceId.cpp
@@ -1,0 +1,112 @@
+/**
+ * @file TestCIccTagXmlProfileSequenceId.cpp
+ * @brief Unit tests for CIccTagXmlProfileSequenceId()
+ * @author @h02332 | David Hoyt | @xsscx
+ * @date 29 MAY  2024
+ * @version 1.0.5
+ *
+ * This unit test is designed to verify the parsing functionality of the
+ * CIccTagXmlProfileSequenceId class from the IccLibXML library. It uses libxml2 to
+ * create a sample XML document and tests how the CIccTagXmlProfileSequenceId class
+ * processes this input. The test checks for both correct and incorrect scenarios.
+ *
+ * Expected Outcomes:
+ *   - When provided with a properly structured XML document, the ParseXml method
+ *     should return true, indicating successful parsing and validation of the XML content.
+ *   - If the XML structure is incorrect or critical elements are missing, the method
+ *     should return false, indicating a failure to correctly parse the XML.
+ *
+ * Compile:
+ *   clang++ -std=c++11 -g -fsanitize=address,undefined -fno-omit-frame-pointer \
+ *    -o TestCIccTagXmlProfileSequenceId TestCIccTagXmlProfileSequenceId.cpp \
+ *    -I/usr/local/include \
+ *    -I/IccProfLib \
+ *    -I/IccXML/IccLibXML \
+ *    -L/Build/IccProfLib \
+ *    -L/Build/IccXML \
+ *    -L/usr/local/Cellar/libxml2/2.12.6/lib/ \
+ *    -lIccProfLib2 -lIccXML2 -lpthread -lxml2
+ *
+ * Usage:
+ *   Compile and run this file to perform the tests. The console output will display
+ *   the test results, showing whether each scenario passed or failed.
+ *
+ * Comment: If you run this Code and think you've found a new, unique and distinct Bug...
+ *          Please Submit a PR to increase improve the CIccTagXmlProfileSequenceId() Unit Test.
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#pragma mark - Headers
+
+/**
+@brief Core and external libraries necessary for the fuzzer functionality.
+
+@details This section includes the necessary headers for the XML parsing library (libxml), the standard I/O stream
+library, and a custom header for the CIccTagXmlProfileSequenceId class. These libraries are essential for handling XML
+documents, performing standard input/output operations, and utilizing the custom functionality of the CIccTagXmlProfileSequenceId class.
+*/
+#include <libxml/parser.h>    // Includes libxml parser functions for XML parsing
+#include <libxml/tree.h>      // Includes libxml tree functions for XML document handling
+#include "IccTagXml.h"        // Includes custom header file for CIccTagXmlProfileSequenceId class definition
+#include <iostream>           // Includes standard I/O stream library for console output
+#include <string>             // Includes standard string library
+
+#pragma mark - Main Entry
+
+/**
+@brief Main function to initiate unit tests for the CIccTagXmlProfileSequenceId class.
+
+@details This function initializes the libxml library, creates a new XML document with a root node and a child node, and
+tests the ParseXml method of the CIccTagXmlProfileSequenceId class. The test result is output to the console. Finally,
+the function cleans up the XML document and the libxml parser to prevent memory leaks.
+
+@return int - Returns 0 upon successful completion.
+*/
+int main() {
+    std::cout << "Starting unit tests for CIccTagXmlProfileSequenceId...\n";
+
+    // Initialize libxml library
+    xmlInitParser();
+
+    // Create a new XML document
+    xmlDocPtr doc = xmlNewDoc(BAD_CAST "1.0");  // Create a new XML document with version 1.0
+    xmlNodePtr rootNode = xmlNewNode(nullptr, BAD_CAST "ProfileSequenceId");  // Create the root node named "ProfileSequenceId"
+    xmlDocSetRootElement(doc, rootNode);  // Set the root node as the document's root element
+
+    // Create a child node named "ProfileIdDesc" with an attribute
+    xmlNodePtr profileNode = xmlNewChild(rootNode, nullptr, BAD_CAST "ProfileIdDesc", nullptr);  // Create a child node under root node
+    xmlNewProp(profileNode, BAD_CAST "id", BAD_CAST "12345");  // Add an attribute "id" with value "12345" to the child node
+
+    // Create a CIccTagXmlProfileSequenceId object
+    CIccTagXmlProfileSequenceId tag;
+    std::string parseStr;
+
+    // Test the parsing function
+    bool parseResult = tag.ParseXml(rootNode, parseStr);  // Call the ParseXml method on the tag object with rootNode
+
+    // Define the test results based on the parseResult
+    if (!parseResult) {
+        std::cout << "Test failed: ParseXml should not return false when a proper node is provided.\n";  // Output failure message if parsing fails
+    } else {
+        std::cout << "Test succeeded: ParseXml correctly handled the provided node.\n";  // Output success message if parsing succeeds
+    }
+
+    // Cleanup
+    xmlFreeDoc(doc);  // Free the document to prevent memory leaks
+    xmlCleanupParser();  // Cleanup the libxml parser
+
+    return 0;  // Return success
+}


### PR DESCRIPTION
This PR: Fixup Xcode SubProject Folders, Address Relative Path Issues, Build Script and Unit Test

## Build Platform
```
kern.version: Darwin Kernel Version 23.5.0: Wed May  1 20:09:52 PDT 2024; root:xnu-10063.121.3~5/RELEASE_X86_64
kern.osversion: 23F79
kern.iossupportversion: 17.5
kern.osproductversioncompat: 10.16
kern.osproductversion: 14.5
/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX14.5.sdk
Apple clang version 15.0.0 (clang-1500.3.9.4)
Target: x86_64-apple-darwin23.5.0
InstalledDir: /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
Darwin Cryptex Management Interface Version 2.0.0: Wed Jun 29 00:19:41 PDT 2022; root:libcryptex_executables-170.100.24~552/cryptexctl/WEN_ETA_X86_64
machdep.cpu.brand_string: Intel(R) Core(TM) i7-8700B CPU @ 3.20GHz
machdep.cpu.brand: 0
```

### Clean
```
rm -rf CMakeCache.txt Release Debug build CMakeFiles CMakeScripts cmake_install.cmake
cmake -G Xcode .
```
### Build

`IccXML/CmdLine/IccFromXml % ./xnu_build_cmd_IccFromXml.zsh | grep "BUILD"`

```
Building scheme 'ALL_BUILD' with configuration 'Debug'...
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project IccFromXml.xcodeproj -scheme ALL_BUILD -configuration Debug -destination platform=macOS,arch=x86_64 clean build
    Target 'ALL_BUILD' in project 'IccFromXml'
...
** BUILD SUCCEEDED **
Building scheme 'ALL_BUILD' with configuration 'Release'...
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project IccFromXml.xcodeproj -scheme ALL_BUILD -configuration Release -destination platform=macOS,arch=x86_64 clean build
    Target 'ALL_BUILD' in project 'IccFromXml'

** BUILD SUCCEEDED **
```

`IccXML/CmdLine/IccToXml % ./xnu_build_cmd_IccToXml.zsh| grep "BUILD"`
```
Building scheme 'ALL_BUILD' with configuration 'Debug'...
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project IccToXml.xcodeproj -scheme ALL_BUILD -configuration Debug -destination platform=macOS,arch=x86_64 clean build
    Target 'ALL_BUILD' in project 'IccToXml'
...
** BUILD SUCCEEDED **
Building scheme 'ALL_BUILD' with configuration 'Release'...
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project IccToXml.xcodeproj -scheme ALL_BUILD -configuration Release -destination platform=macOS,arch=x86_64 clean build
    Target 'ALL_BUILD' in project 'IccToXml'
...
** BUILD SUCCEEDED **
Building scheme 'ALL_BUILD' with configuration 'MinSizeRel'...
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project IccToXml.xcodeproj -scheme ALL_BUILD -configuration MinSizeRel -destination platform=macOS,arch=x86_64 clean build
    Target 'ALL_BUILD' in project 'IccToXml'
...
** BUILD SUCCEEDED **
Building scheme 'ALL_BUILD' with configuration 'RelWithDebInfo'...
    /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild -project IccToXml.xcodeproj -scheme ALL_BUILD -configuration RelWithDebInfo -destination platform=macOS,arch=x86_64 clean build
    Target 'ALL_BUILD' in project 'IccToXml'
...
** BUILD SUCCEEDED **
```

## Unit Test for TestCIccTagXmlProfileSequenceId()
`TestCIccTagXmlProfileSequenceId.cpp`: This unit test is designed to verify the parsing functionality of the CIccTagXmlProfileSequenceId class from the IccLibXML library. It uses libxml2 to create a sample XML document and tests how the CIccTagXmlProfileSequenceId class processes this input. The test checks for both correct and incorrect scenarios.