### PR TITLE
Fix build errors in IccCmm header on Linux

### DIFF
--- a/Build/Cmake/CMakeLists.txt
+++ b/Build/Cmake/CMakeLists.txt
@@ -148,6 +148,7 @@ IF(ENABLE_ICCXML)
 ENDIF()
 
 IF(ENABLE_TOOLS)
+  ADD_SUBDIRECTORY( Tools/IccCommon )
   ADD_SUBDIRECTORY( Tools/IccApplyNamedCmm )
   ADD_SUBDIRECTORY( Tools/IccDumpProfile )
   ADD_SUBDIRECTORY( Tools/IccRoundTrip )

--- a/Build/Cmake/Tools/IccCommon/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccCommon/CMakeLists.txt
@@ -1,0 +1,16 @@
+SET( SRC_PATH ../../../.. )
+SET( SOURCES
+        ${SRC_PATH}/Tools/CmdLine/IccCommon/IccCmmConfig.h
+        ${SRC_PATH}/Tools/CmdLine/IccCommon/IccCmmConfig.cpp
+        ${SRC_PATH}/Tools/CmdLine/IccCommon/IccJsonUtil.h
+        ${SRC_PATH}/Tools/CmdLine/IccCommon/IccJsonUtil.cpp )
+
+SET( TARGET_NAME IccCommon )
+INCLUDE_DIRECTORIES ( ${SRC_PATH}/Tools/CmdLine/IccCommon/ )
+
+ADD_EXECUTABLE( ${TARGET_NAME} ${SOURCES} )
+TARGET_LINK_LIBRARIES( ${TARGET_NAME} ${TARGET_LIB_ICCPROFLIB} )
+
+IF(ENABLE_INSTALL_RIM)
+    INSTALL (TARGETS ${TARGET_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+ENDIF(ENABLE_INSTALL_RIM)

--- a/IccProfLib/IccCmm.h
+++ b/IccProfLib/IccCmm.h
@@ -1238,6 +1238,7 @@ protected:
   const CIccMatrix* m_ApplyMatrixPtr;
 };
 
+class CIccXformNDLut;
 
 class ICCPROFLIB_API CIccApplyNDLutXform : public CIccApplyXform
 {

--- a/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
+++ b/Tools/CmdLine/IccApplyNamedCmm/iccApplyNamedCmm.cpp
@@ -78,7 +78,7 @@
 #include "IccEnvVar.h"
 #include "IccMpeCalc.h"
 #include "IccProfLibVer.h"
-#include "..\IccCommon\IccCmmConfig.h"
+#include "IccCmmConfig.h"
 
 
 using namespace nlohmann;

--- a/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
+++ b/Tools/CmdLine/IccApplyProfiles/iccApplyProfiles.cpp
@@ -76,7 +76,7 @@
 #include "IccDefs.h"
 #include "IccApplyBPC.h"
 #include "IccEnvVar.h"
-#include "..\IccCommon\IccCmmConfig.h"
+#include "IccCmmConfig.h"
 #include "TiffImg.h"
 #include "IccProfLibVer.h"
 


### PR DESCRIPTION
Added missing forward declaration for the `CIccXformNDLut` class to accommodate friend declaration within `CIccApplyNDLutXform` - friend declaration alone does not constitute a general declaration

Build error was: 
`IccCmm.h:1246:37 error: expected ')' before '*' token`