### PR TITLE
Create SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Reporting Security Issues
+
+The International Color Consoritum (ICC) takes security very seriously. We appreciate your efforts to responsibly disclose your findings, and will make every effort to acknowledge your contributions.
+
+To report a security issue, please use the GitHub Security Advisory 
+["Report a Vulnerability"](https://github.com/InternationalColorConsortium/DemoIccMAX/security/advisories/new) tab.
+
+The ICC will send a response indicating the next steps in handling your report. After the initial reply to your report, the security team will keep you informed of the progress towards a fix and full announcement, and may ask for additional information or guidance.


### PR DESCRIPTION
@maxderhak I enabled the GitHub Security Advisory "Report a Vulnerability" for this repo. The SECURITY.md file in this commit populates the instructions under the repo's security tab.