### PR TITLE
IccJpegDump CMakeLists.txt: skip build if Ubuntu version cannot be determined

### DIFF
--- a/Build/Cmake/Tools/IccJpegDump/CMakeLists.txt
+++ b/Build/Cmake/Tools/IccJpegDump/CMakeLists.txt
@@ -31,8 +31,19 @@ if(UNIX AND EXISTS "/etc/lsb-release")
     )
     message(STATUS "Detected Ubuntu version: ${LSB_VERSION}")
     string(REGEX MATCHALL "[0-9]+" LSB_VERSION_PARTS "${LSB_VERSION}")
+
+    if (NOT LSB_VERSION_PARTS)
+        message(WARNING "iccJpegDump is skipped: couldn't be able to detect Ubuntu version")
+        return()
+    endif()
+
     list(GET LSB_VERSION_PARTS 0 UBUNTU_MAJOR)
     list(GET LSB_VERSION_PARTS 1 UBUNTU_MINOR)
+
+    if(NOT UBUNTU_MAJOR OR NOT UBUNTU_MINOR)
+        message(WARNING "iccJpegDump is skipped: couldn't be able to detect Ubuntu version")
+        return()
+    endif()
 
     math(EXPR LSB_VERSION_COMBINED "${UBUNTU_MAJOR} * 100 + ${UBUNTU_MINOR}")
     if(LSB_VERSION_COMBINED LESS 2404)


### PR DESCRIPTION
For some reason `lsb_release -rs` may not output anything which leads to this error:
```
  -- TIFF library found: /home/linuxbrew/.linuxbrew/lib/libtiff.so
  -- Adding subdirectory IccSpecSepToTiff.
  -- Adding Subdirectory IccTiffDump.
  -- Adding Subdirectory IccFromXml.
  -- Adding Subdirectory IccToXml.
  -- Adding Subdirectory IccJpegDump.
  -- Detected Ubuntu version: 
  CMake Error at Tools/IccJpegDump/CMakeLists.txt:34 (list):
    list GET given empty list
  
  
  CMake Error at Tools/IccJpegDump/CMakeLists.txt:35 (list):
    list GET given empty list
  
  
  CMake Error at Tools/IccJpegDump/CMakeLists.txt:37 (math):
    math cannot parse the expression: " * 100 + ": syntax error, unexpected
    exp_TIMES (2).
```

Related to Homebrew/homebrew-core#230537