### PR TITLE
Update IccTagMPE.cpp

### DIFF
--- a/IccProfLib/IccTagMPE.cpp
+++ b/IccProfLib/IccTagMPE.cpp
@@ -1116,7 +1116,7 @@ bool CIccTagMultiProcessElement::Write(CIccIO *pIO)
     icUInt32Number offsetPos = pIO->Tell();
 
     if (m_position) {
-      delete [] m_position;
+      free(m_position);
     }
 
     m_position = (icPositionNumber*)calloc(m_nProcElements, sizeof(icPositionNumber));


### PR DESCRIPTION
Memory allocated with calloc is deallocated using free instead of delete [].