### PR TITLE
Modify Runner Permisions to PoLP

### DIFF
--- a/.github/workflows/iccmax-ci-matrix-17-july-2025.yaml
+++ b/.github/workflows/iccmax-ci-matrix-17-july-2025.yaml
@@ -7,8 +7,8 @@
 #
 ## Intent: iccMAX-CI Runner for Matrix OS
 #
-## Last Updated: 17-JULY-2025 2030Z by David Hoyt 
-#
+## Last Updated: 24-JULY-2025 0000Z by David Hoyt 
+#                Add Permission Block
 ## TODO: Push binary releases, tags etc...
 #
 ## Comment: Known good and working
@@ -20,7 +20,9 @@
 ###############################################################
 
 name: iccMAX-CI
-
+permissions:
+  contents: read
+  
 on:
   workflow_dispatch:
 

--- a/.github/workflows/iccmax-scan-build-linux-17-july-2025.yaml
+++ b/.github/workflows/iccmax-scan-build-linux-17-july-2025.yaml
@@ -7,8 +7,8 @@
 #
 ## Intent: iccMAX Scan Build Runner for Matrix OS
 #
-## Last Updated: 17-JULY-2025 2000Z by David Hoyt 
-#
+## Last Updated: 24-JULY-2025 0000Z by David Hoyt 
+##               Add Read Permission Block
 ## TODO: Push binary releases, tags etc.. 
 #
 ## Comment: Known good and working from PatchIccMax
@@ -28,6 +28,9 @@ jobs:
   build-linux:
     name: Build and Test Linux with scan-build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    
     strategy:
       fail-fast: false
 

--- a/.github/workflows/iccmax-scan-demo-17-july-2025.yaml
+++ b/.github/workflows/iccmax-scan-demo-17-july-2025.yaml
@@ -7,8 +7,8 @@
 #
 ## Intent: Icc Scanner Demo
 #
-## Last Updated: 17-JULY-2025 2000Z by David Hoyt 
-#
+## Last Updated: 24-JULY-2025 0000Z by David Hoyt 
+#                Add Permission Block
 ## TODO: Push binary releases, tags etc.. 
 #
 ## Comment: Known good and working from PatchIccMax
@@ -28,6 +28,8 @@ jobs:
   build-linux:
     name: ICC Scanner Demo
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
 

--- a/.github/workflows/iccmax-win-cmake-17-july-2025.yaml
+++ b/.github/workflows/iccmax-win-cmake-17-july-2025.yaml
@@ -7,8 +7,8 @@
 #
 ## Intent: iccMAX for Cmake Windows Build
 #
-## Last Updated: 17-JULY-2025 2000Z by David Hoyt 
-#
+## Last Updated: 24-JULY-2025 0000Z by David Hoyt 
+#                Add Permission Block
 ## TODO: Push binary releases, tags etc.. 
 #
 ## Comment: Known good and working from PatchIccMax
@@ -20,6 +20,8 @@
 ###############################################################
 
 name: WindowsCmake
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.